### PR TITLE
Fix suffix matching index problem.

### DIFF
--- a/autobahn/autobahn/wamp/uri.py
+++ b/autobahn/autobahn/wamp/uri.py
@@ -83,8 +83,8 @@ class Pattern:
       components = uri.split('.')
       pl = []
       nc = {}
-      i = 0
-      for component in components:
+      for i in range(len(components)):
+         component = components[i]
 
          match = Pattern._URI_NAMED_CONVERTED_COMPONENT.match(component)
          if match:


### PR DESCRIPTION
Currently "<name:suffix>" always produces an "invalid URI" exception for any URI pattern with more than one component because the index variable is never incremented. This fixes that.