### PR TITLE
Fix parsing of IPv6 host headers.

### DIFF
--- a/autobahn/autobahn/websocket/protocol.py
+++ b/autobahn/autobahn/websocket/protocol.py
@@ -2883,8 +2883,8 @@ class WebSocketServerProtocol(WebSocketProtocol):
 
          self.http_request_host = self.http_headers["host"].strip()
 
-         if self.http_request_host.find(":") >= 0:
-            (h, p) = self.http_request_host.split(":")
+         if self.http_request_host.find(":") >= 0 and not self.http_request_host.endswith(']'):
+            (h, p) = self.http_request_host.rsplit(":", 1)
             try:
                port = int(str(p.strip()))
             except ValueError:


### PR DESCRIPTION
IPv6 host headers have the form
```Host: [2a02:1234:5678:9012:3456:abab:abab:abab]:9000```
Therefore it is incorrect to split at each colon. Only the last one must be used.
If the default port is used the header has the form
```Host: [2a02:1234:5678:9012:3456:abab:abab:abab]```
and therefore no port must be read from the header if it ends with ']'.

Before this patch I was getting
```
2015-01-21 23:28:33+0100 [SensorDataProtocol,0,2a02:1234:5678:9012:3456:7890:1234:5678] received HTTP request:
        
        b'GET / HTTP/1.1\r\nHost: [2a02:1234:5678:9012:3456:abab:abab:abab]:9000\r\nConnection: Upgrade\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUpgrade: websocket\r\nOrigin: null\r\nSec-WebSocket-Version: 13\r\nDNT: 1\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\nAccept-Encoding: gzip, deflate, sdch\r\nAccept-Language: en-US,en;q=0.8,de;q=0.6\r\nSec-WebSocket-Key: ToztzvmIRhEwPhKaIbEXkg==\r\nSec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n\r\n'
        
        
2015-01-21 23:28:33+0100 [SensorDataProtocol,0,2a02:1234:5678:9012:3456:7890:1234:5678] received HTTP status line in opening handshake : GET / HTTP/1.1
2015-01-21 23:28:33+0100 [SensorDataProtocol,0,2a02:1234:5678:9012:3456:7890:1234:5678] received HTTP headers in opening handshake : {'sec-websocket-key': 'ToztzvmIRhEwPhKaIbEXkg==', 'accept-encoding': 'gzip, deflate, sdch', 'connection': 'Upgrade', 'dnt': '1', 'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits', 'sec-websocket-version': '13', 'origin': 'null', 'pragma': 'no-cache', 'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36', 'accept-language': 'en-US,en;q=0.8,de;q=0.6', 'cache-control': 'no-cache', 'upgrade': 'websocket', 'host': '[2a02:1234:5678:9012:3456:abab:abab:abab]:9000'}
2015-01-21 23:28:33+0100 [SensorDataProtocol,0,2a02:1234:5678:9012:3456:7890:1234:5678] Unhandled Error
        Traceback (most recent call last):
          File "/usr/local/lib/python3.4/dist-packages/twisted/python/log.py", line 88, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/usr/local/lib/python3.4/dist-packages/twisted/python/log.py", line 73, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/local/lib/python3.4/dist-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/local/lib/python3.4/dist-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/usr/local/lib/python3.4/dist-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
            why = selectable.doRead()
          File "/usr/local/lib/python3.4/dist-packages/twisted/internet/tcp.py", line 214, in doRead
            return self._dataReceived(data)
          File "/usr/local/lib/python3.4/dist-packages/twisted/internet/tcp.py", line 220, in _dataReceived
            rval = self.protocol.dataReceived(data)
          File "/usr/local/lib/python3.4/dist-packages/autobahn/twisted/websocket.py", line 96, in dataReceived
            self._dataReceived(data)
          File "/usr/local/lib/python3.4/dist-packages/autobahn/websocket/protocol.py", line 1328, in _dataReceived
            self.consumeData()
          File "/usr/local/lib/python3.4/dist-packages/autobahn/websocket/protocol.py", line 1361, in consumeData
            self.processHandshake()
          File "/usr/local/lib/python3.4/dist-packages/autobahn/websocket/protocol.py", line 2882, in processHandshake
            (h, p) = self.http_request_host.split(":")
        builtins.ValueError: too many values to unpack (expected 2)
```