### PR TITLE
wildcard subscribe support in decorator

### DIFF
--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -835,7 +835,8 @@ class ApplicationSession(BaseSession):
                     pat = proc.__dict__["_wampuris"][0]
                     if pat.is_handler():
                         uri = pat.uri()
-                        dl.append(_subscribe(handler, proc, uri, options))
+                        subopts = options or pat.subscribe_options()
+                        dl.append(_subscribe(handler, proc, uri, subopts))
             return self._gather_futures(dl, consume_exceptions=True)
 
     def _unsubscribe(self, subscription):

--- a/autobahn/autobahn/wamp/uri.py
+++ b/autobahn/autobahn/wamp/uri.py
@@ -18,6 +18,7 @@
 
 import re
 import six
+from autobahn.wamp.types import SubscribeOptions
 
 __all__ = ('Pattern',)
 
@@ -147,6 +148,12 @@ class Pattern:
         :rtype: unicode
         """
         return self._uri
+
+    def subscribe_options(self):
+        if self._type == Pattern.URI_TYPE_WILDCARD:
+            return SubscribeOptions(match=u"wildcard")
+        else:
+            return SubscribeOptions(match=u"exact")
 
     def match(self, uri):
         """


### PR DESCRIPTION
While debugging while wildcard support didn't work I first fixed this issue in autobahn.
