### PR TITLE
Handle connection errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - pip install tox 
+  - pip install tox mock
 
 env:
   - TOX_ENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - pip install tox mock
+  - pip install tox
 
 env:
   - TOX_ENV=flake8

--- a/autobahn/autobahn/twisted/wamp.py
+++ b/autobahn/autobahn/twisted/wamp.py
@@ -173,6 +173,7 @@ class ApplicationRunner:
 
         class ErrorCollector:
             exception = None
+
             def __call__(self, failure):
                 self.exception = failure.value
                 # print(failure.getErrorMessage())

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -18,8 +18,10 @@
 
 from __future__ import absolute_import
 
-# from twisted.trial import unittest
-import unittest2
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 from mock import patch
 
 
@@ -43,7 +45,7 @@ class FakeReactor:
         raise RuntimeError("ConnectTCP shouldn't get called")
 
 
-class TestWampTwistedRunner(unittest2.TestCase):
+class TestWampTwistedRunner(unittest.TestCase):
 
     def test_connect_error(self):
         '''
@@ -56,7 +58,7 @@ class TestWampTwistedRunner(unittest2.TestCase):
             # the 'reactor' member doesn't exist until we import it
             from twisted.internet import reactor  # noqa: F401
         except ImportError:
-            raise unittest2.SkipTest('No twisted')
+            raise unittest.SkipTest('No twisted')
 
         runner = ApplicationRunner('ws://localhost:1', 'realm')
         exception = ConnectionRefusedError("It's a trap!")

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -20,14 +20,15 @@ from __future__ import absolute_import
 
 # from twisted.trial import unittest
 import unittest
-import platform
 from mock import patch
+
 
 class FakeReactor:
     '''
     This just fakes out enough reactor methods so .run() can work.
     '''
     stop_called = False
+
     def __init__(self, to_raise):
         self.stop_called = False
         self.to_raise = to_raise
@@ -53,7 +54,7 @@ class TestWampTwistedRunner(unittest.TestCase):
             from autobahn.twisted.wamp import ApplicationRunner
             from twisted.internet.error import ConnectionRefusedError
             # the 'reactor' member doesn't exist until we import it
-            from twisted.internet import reactor
+            from twisted.internet import reactor  # noqa: F401
         except ImportError:
             raise unittest.SkipTest('No twisted')
 

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -23,10 +23,6 @@ import unittest
 import platform
 from mock import patch
 
-from twisted.internet.error import ConnectionRefusedError
-
-from autobahn.twisted.wamp import ApplicationRunner
-
 class FakeReactor:
     '''
     This just fakes out enough reactor methods so .run() can work.
@@ -53,10 +49,16 @@ class TestWampTwistedRunner(unittest.TestCase):
         Ensure the runner doesn't swallow errors and that it exits the
         reactor properly if there is one.
         '''
+        try:
+            from autobahn.twisted.wamp import ApplicationRunner
+            from twisted.internet.error import ConnectionRefusedError
+            # the 'reactor' member doesn't exist until we import it
+            from twisted.internet import reactor
+        except ImportError:
+            raise unittest.SkipTest('No twisted')
+
         runner = ApplicationRunner('ws://localhost:1', 'realm')
         exception = ConnectionRefusedError("It's a trap!")
-        # the 'reactor' member doesn't exist until we import it
-        from twisted.internet import reactor
 
         with patch('twisted.internet.reactor', FakeReactor(exception)) as mockreactor:
             self.assertRaises(

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -1,0 +1,48 @@
+###############################################################################
+##
+# Copyright (C) 2014 Tavendo GmbH
+##
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+##
+# http://www.apache.org/licenses/LICENSE-2.0
+##
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+###############################################################################
+
+from __future__ import absolute_import
+
+# from twisted.trial import unittest
+import unittest
+import platform
+
+from twisted.internet.error import DNSLookupError
+from twisted.internet.error import ConnectionRefusedError
+
+from autobahn.twisted.wamp import ApplicationRunner
+
+class TestWampTwistedRunner(unittest.TestCase):
+
+    def test_connect_error(self):
+        '''
+        Ensure the runner doesn't swallow errors, and exit the reactor
+        properly if there is one.
+        '''
+        runner = ApplicationRunner('ws://localhost:1', 'realm')
+
+        # FIXME: we're really running the reactor here; that's not so awesome...
+        # could we pass a reactor to the runner somehow?
+        self.assertRaises(
+            ConnectionRefusedError,
+            # pass a no-op session-creation method
+            runner.run, lambda _: None
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -19,7 +19,7 @@
 from __future__ import absolute_import
 
 # from twisted.trial import unittest
-import unittest
+import unittest2
 from mock import patch
 
 
@@ -43,7 +43,7 @@ class FakeReactor:
         raise RuntimeError("ConnectTCP shouldn't get called")
 
 
-class TestWampTwistedRunner(unittest.TestCase):
+class TestWampTwistedRunner(unittest2.TestCase):
 
     def test_connect_error(self):
         '''
@@ -56,7 +56,7 @@ class TestWampTwistedRunner(unittest.TestCase):
             # the 'reactor' member doesn't exist until we import it
             from twisted.internet import reactor  # noqa: F401
         except ImportError:
-            raise unittest.SkipTest('No twisted')
+            raise unittest2.SkipTest('No twisted')
 
         runner = ApplicationRunner('ws://localhost:1', 'realm')
         exception = ConnectionRefusedError("It's a trap!")

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -90,7 +90,9 @@ setenv =
 
 
 [testenv:py33asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -16,7 +16,9 @@ whitelist_externals = sh
 
 
 [testenv:flake8]
-deps = flake8
+deps =
+   flake8
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -29,6 +31,7 @@ basepython = python2.7
 deps =
    twisted
    unittest2
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -45,6 +48,7 @@ setenv =
 deps =
    pytest
    unittest2
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -56,7 +60,9 @@ setenv =
 
 
 [testenv:py27twisted]
-deps = twisted
+deps =
+   twisted
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -70,7 +76,9 @@ setenv =
 
 
 [testenv:py27asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -94,7 +102,9 @@ setenv =
 
 
 [testenv:py34asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -106,7 +116,9 @@ setenv =
 
 
 [testenv:pypy2twisted]
-deps = twisted
+deps =
+   twisted
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -120,7 +132,9 @@ setenv =
 
 
 [testenv:pypy2asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V


### PR DESCRIPTION
ApplicationRunner.run() ignores the Deferred from .connect() which means if there's a connection problem, run() won't exit the event-loop and no exception will be raised to the caller. Minimal test-case:

```python
from autobahn.twisted.wamp import ApplicationSession
from autobahn.twisted.wamp import ApplicationRunner

class Session(ApplicationSession):
    pass

runner = ApplicationRunner('ws://localhost:1', 'realm')
runner.run(Session) 
```