### PR TITLE
Handle connection errors in ApplicationRunner.run()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - pip install tox 
+  - pip install tox
 
 env:
   - TOX_ENV=flake8

--- a/autobahn/autobahn/twisted/wamp.py
+++ b/autobahn/autobahn/twisted/wamp.py
@@ -165,11 +165,30 @@ class ApplicationRunner:
             endpoint_descriptor = "tcp:{0}:{1}".format(host, port)
 
         client = clientFromString(reactor, endpoint_descriptor)
-        client.connect(transport_factory)
+        d = client.connect(transport_factory)
+
+        # if an error happens on the connect(), we save the underlying
+        # exception so that after the event-loop exits we can re-raise
+        # it to the caller.
+
+        class ErrorCollector:
+            exception = None
+
+            def __call__(self, failure):
+                self.exception = failure.value
+                # print(failure.getErrorMessage())
+                reactor.stop()
+        connect_error = ErrorCollector()
+        d.addErrback(connect_error)
 
         # now enter the Twisted reactor loop
         if start_reactor:
             reactor.run()
+
+        # if we exited due to a connection error, raise that to the
+        # caller
+        if connect_error.exception:
+            raise connect_error.exception
 
 
 class _ApplicationSession(ApplicationSession):

--- a/autobahn/autobahn/wamp/test/test_runner.py
+++ b/autobahn/autobahn/wamp/test/test_runner.py
@@ -1,0 +1,75 @@
+###############################################################################
+##
+# Copyright (C) 2014 Tavendo GmbH
+##
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+##
+# http://www.apache.org/licenses/LICENSE-2.0
+##
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+###############################################################################
+
+from __future__ import absolute_import
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from mock import patch
+
+
+class FakeReactor:
+    '''
+    This just fakes out enough reactor methods so .run() can work.
+    '''
+    stop_called = False
+
+    def __init__(self, to_raise):
+        self.stop_called = False
+        self.to_raise = to_raise
+
+    def run(self, *args, **kw):
+        raise self.to_raise
+
+    def stop(self):
+        self.stop_called = True
+
+    def connectTCP(self, *args, **kw):
+        raise RuntimeError("ConnectTCP shouldn't get called")
+
+
+class TestWampTwistedRunner(unittest.TestCase):
+
+    def test_connect_error(self):
+        '''
+        Ensure the runner doesn't swallow errors and that it exits the
+        reactor properly if there is one.
+        '''
+        try:
+            from autobahn.twisted.wamp import ApplicationRunner
+            from twisted.internet.error import ConnectionRefusedError
+            # the 'reactor' member doesn't exist until we import it
+            from twisted.internet import reactor  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest('No twisted')
+
+        runner = ApplicationRunner('ws://localhost:1', 'realm')
+        exception = ConnectionRefusedError("It's a trap!")
+
+        with patch('twisted.internet.reactor', FakeReactor(exception)) as mockreactor:
+            self.assertRaises(
+                ConnectionRefusedError,
+                # pass a no-op session-creation method
+                runner.run, lambda _: None, start_reactor=True
+            )
+            self.assertTrue(mockreactor.stop_called)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -16,7 +16,9 @@ whitelist_externals = sh
 
 
 [testenv:flake8]
-deps = flake8
+deps =
+   flake8
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -29,6 +31,7 @@ basepython = python2.7
 deps =
    twisted
    unittest2
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -45,6 +48,7 @@ setenv =
 deps =
    pytest
    unittest2
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -56,7 +60,9 @@ setenv =
 
 
 [testenv:py27twisted]
-deps = twisted
+deps =
+   twisted
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -70,7 +76,9 @@ setenv =
 
 
 [testenv:py27asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -82,7 +90,9 @@ setenv =
 
 
 [testenv:py33asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -94,7 +104,9 @@ setenv =
 
 
 [testenv:py34asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V
@@ -106,7 +118,9 @@ setenv =
 
 
 [testenv:pypy2twisted]
-deps = twisted
+deps =
+   twisted
+   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -120,7 +134,9 @@ setenv =
 
 
 [testenv:pypy2asyncio]
-deps = pytest
+deps =
+   pytest
+   mock
 commands =
    sh -c "which python"
    python -V


### PR DESCRIPTION

ApplicationRunner.run() ignores the Deferred from .connect() which means if there's a connection problem, run() won't exit the event-loop and no exception will be raised to the caller. Minimal test-case:

```python
from autobahn.twisted.wamp import ApplicationSession
from autobahn.twisted.wamp import ApplicationRunner

class Session(ApplicationSession):
    pass

runner = ApplicationRunner('ws://localhost:1', 'realm')
runner.run(Session) 
```
