### PR TITLE
Callback exception handling

### DIFF
--- a/autobahn/autobahn/twisted/wamp.py
+++ b/autobahn/autobahn/twisted/wamp.py
@@ -86,6 +86,14 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
     WAMP application session for Twisted-based applications.
     """
 
+    def onUserError(self, e):
+        """
+        Override of wamp.ApplicationSession
+        """
+        # see docs; will print currently-active exception to the logs,
+        # which is just what we want.
+        log.err()
+
 
 class ApplicationSessionFactory(FutureMixin, protocol.ApplicationSessionFactory):
     """

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -462,7 +462,7 @@ class ApplicationSession(BaseSession):
                         self.onUserError(e)
                         if self.debug_app:
                             traceback.print_exc()
-                            print('While firing {} subscribed under "{0}" ("{1}").'.format(
+                            print('While firing {0} subscribed under "{1}" ("{2}").'.format(
                                 handler.fn, handler.topic, msg.subscription))
 
                 else:

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -377,6 +377,18 @@ class ApplicationSession(BaseSession):
         else:
             raise Exception("transport disconnected")
 
+    def onUserError(self, e):
+        """
+        This is called when we try to fire a callback, but get an
+        exception from user code -- for example, a registered publish
+        callback or a registered method. Intended to be overridden in
+        the Twisted or asyncio ApplicationSession objects where proper
+        logging can be provided.
+
+        :param e: the Exception we caught.
+        """
+        pass
+
     def onMessage(self, msg):
         """
         Implements :func:`autobahn.wamp.interfaces.ITransportHandler.onMessage`

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -483,8 +483,9 @@ class ApplicationSession(BaseSession):
                     sub_id = msg.subscription
                     # we should NEVER have our ID subscribed already
                     if sub_id in self._subscriptions:
-                        raise RuntimeError(
-                            'Duplicate subscription "{}".'.format(sub_id))
+                        raise ProtocolError(
+                            'SUBSCRIBED received with existing subscription:' +
+                            str(sub_id) + ' (request ID "{}").'.format(msg.request))
 
                     details = options.details_arg if options else None
                     handler = Handler(obj, fn, topic, details)

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -462,7 +462,7 @@ class ApplicationSession(BaseSession):
                         self.onUserError(e)
                         if self.debug_app:
                             traceback.print_exc()
-                            print('While firing {} subscribed under "{}" ("{}").'.format(
+                            print('While firing {} subscribed under "{0}" ("{1}").'.format(
                                 handler.fn, handler.topic, msg.subscription))
 
                 else:
@@ -485,7 +485,7 @@ class ApplicationSession(BaseSession):
                     if sub_id in self._subscriptions:
                         raise ProtocolError(
                             'SUBSCRIBED received with existing subscription:' +
-                            str(sub_id) + ' (request ID "{}").'.format(msg.request))
+                            str(sub_id) + ' (request ID "{0}").'.format(msg.request))
 
                     details = options.details_arg if options else None
                     handler = Handler(obj, fn, topic, details)

--- a/autobahn/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/autobahn/wamp/test/test_protocol.py
@@ -31,7 +31,7 @@ import os
 if os.environ.get('USE_TWISTED', False):
 
     from six import StringIO
-    from mock import Mock, patch
+    from mock import Mock
     from twisted.trial import unittest
     # import unittest
 
@@ -41,7 +41,7 @@ if os.environ.get('USE_TWISTED', False):
     from autobahn.wamp import serializer
     from autobahn.wamp import role
     from autobahn import util
-    from autobahn.wamp.exception import ApplicationError, NotAuthorized, InvalidUri
+    from autobahn.wamp.exception import ApplicationError, NotAuthorized, InvalidUri, ProtocolError
     from autobahn.wamp import types
 
     from autobahn.twisted.wamp import ApplicationSession
@@ -54,7 +54,6 @@ if os.environ.get('USE_TWISTED', False):
             self._serializer = serializer.JsonSerializer()
             self._registrations = {}
             self._invocations = {}
-            self._topic_subscriptions = {}
 
             self._handler.onOpen(self)
 
@@ -106,14 +105,7 @@ if os.environ.get('USE_TWISTED', False):
                     reply = message.Result(request, args=msg.args, kwargs=msg.kwargs)
 
             elif isinstance(msg, message.Subscribe):
-                # fake out that we can do duplicate subscriptions to
-                # the same topic
-                if msg.topic in self._topic_subscriptions:
-                    reply_id = self._topic_subscriptions[msg.topic]
-                else:
-                    reply_id = util.id()
-                    self._topic_subscriptions[msg.topic] = reply_id
-                reply = message.Subscribed(msg.request, reply_id)
+                reply = message.Subscribed(msg.request, util.id())
 
             elif isinstance(msg, message.Unsubscribe):
                 reply = message.Unsubscribed(msg.request)
@@ -263,27 +255,120 @@ if os.environ.get('USE_TWISTED', False):
             event0 = Deferred()
             event1 = Deferred()
 
-            subscription0 = yield handler.subscribe(lambda: event0.callback(42), u'com.myapp.topic1')
-            subscription1 = yield handler.subscribe(lambda: event1.callback('foo'), u'com.myapp.topic1')
-            # same topic, *HAS* to be the same ID for protocol to
-            # work, because "EVENT, SUBSCRIBED.Subscription|id" is the
-            # only way to send one.
-            self.assertTrue(subscription0.id == subscription1.id)
+            subscription0 = yield handler.subscribe(
+                lambda: event0.callback(42), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                lambda: event1.callback('foo'), u'com.myapp.topic1')
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
 
-            # do a publish, and then fake the acknowledgement message
+            # do a publish (MockTransport fakes the acknowledgement
+            # message) and then do an actual publish event
+            # it would be up to the router (broker) to send out
+            # multiple Events when appropriate, so we do that here
             publish = yield handler.publish(
                 u'com.myapp.topic1',
                 options=types.PublishOptions(acknowledge=True, exclude_me=False),
             )
-            msg = message.Event(subscription0.id, publish.id)
-            handler.onMessage(msg)
+            handler.onMessage(message.Event(subscription0.id, publish.id))
+            handler.onMessage(message.Event(subscription1.id, publish.id))
 
-            # ensure that the publish "did the right thing" and called
-            # both callbacks
-            self.assertTrue(event0.called, "Didn't get first subscribe's callback")
-            self.assertTrue(event1.called, "Didn't get second subscribe's callback")
+            # ensure we actually got both callbacks
+            self.assertTrue(event0.called, "Missing callback")
+            self.assertTrue(event1.called, "Missing callback")
 
+        @inlineCallbacks
+        def test_double_subscribe_single_unsubscribe(self):
+            '''
+            Make sure we correctly deal with unsubscribing one of our handlers
+            from the same topic.
+            '''
+            handler = ApplicationSession()
+            MockTransport(handler)
 
+            event0 = Deferred()
+            event1 = Deferred()
+
+            subscription0 = yield handler.subscribe(
+                lambda: event0.callback(42), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                lambda: event1.callback('foo'), u'com.myapp.topic1')
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
+            yield subscription1.unsubscribe()
+
+            # do a publish (MockTransport fakes the acknowledgement
+            # message) and then do an actual publish event
+            # it would be up to the router (broker) to send out
+            # multiple Events when appropriate, so we do that here
+            publish = yield handler.publish(
+                u'com.myapp.topic1',
+                options=types.PublishOptions(acknowledge=True, exclude_me=False),
+            )
+            handler.onMessage(message.Event(subscription0.id, publish.id))
+            try:
+                handler.onMessage(message.Event(subscription1.id, publish.id))
+                self.fail("Should get exception for unsubscribed topic")
+            except ProtocolError as e:
+                pass
+
+            # since we unsubscribed the second event handler, we
+            # should NOT have called its callback
+            self.assertTrue(event0.called, "Missing callback")
+            self.assertTrue(not event1.called, "Second callback fired.")
+
+        @inlineCallbacks
+        def test_double_subscribe_errors(self):
+            """
+            Test various error-conditions when we try to add a second
+            subscription-handler (its signature must match any
+            existing handlers).
+            """
+            handler = ApplicationSession()
+            MockTransport(handler)
+
+            event0 = Deferred()
+            event1 = Deferred()
+
+            def second(*args, **kw):
+                # our EventDetails should have been passed as the
+                # "boom" kwarg; see "details_arg=" below
+                self.assertTrue('boom' in kw)
+                self.assertTrue(isinstance(kw['boom'], types.EventDetails))
+                event1.callback(args)
+
+            subscription0 = yield handler.subscribe(
+                lambda arg: event0.callback(arg), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                second, u'com.myapp.topic1',
+                types.SubscribeOptions(details_arg='boom'),
+            )
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
+
+            # MockTransport gives us the ack reply and then we do our
+            # own event messages. We need two, since it would be up to
+            # a Router/Broker to correctly hand out two Event messages
+            # if two callbacks are registered for the same topic
+            # string
+            publish = yield handler.publish(
+                u'com.myapp.topic1',
+                options=types.PublishOptions(acknowledge=True, exclude_me=False),
+            )
+            # note that the protocol serializer converts all sequences
+            # to lists, so we pass "args" as a list, not a tuple on
+            # purpose.
+            handler.onMessage(
+                message.Event(subscription0.id, publish.id, args=['arg0']))
+            handler.onMessage(
+                message.Event(subscription1.id, publish.id, args=['arg0']))
+
+            # each callback should have gotten called, each with its
+            # own args (we check the correct kwarg in second() above)
+            self.assertTrue(event0.called)
+            self.assertTrue(event1.called)
+            self.assertEqual(event0.result, 'arg0')
+            self.assertEqual(event1.result, ('arg0',))
 
         @inlineCallbacks
         def test_publish_callback_exception(self):
@@ -305,6 +390,7 @@ if os.environ.get('USE_TWISTED', False):
             sys.stdout = StringIO()
             try:
                 error_instance = RuntimeError("we have a problem")
+
                 def boom():
                     raise error_instance
 

--- a/autobahn/setup.py
+++ b/autobahn/setup.py
@@ -155,7 +155,7 @@ setup(
         # needed if you want WAMPv2 binary serialization support
         'serialization': ["msgpack-python>=0.4.0"],
 
-        'dev': ["pep8", "flake8", "mock>=1.0.1"],
+        'dev': ["pep8", "flake8", "mock>=1.0.1", "pytest>=2.6.4"],
     },
     tests_require=test_requirements,
     cmdclass={'test': PyTest},

--- a/autobahn/setup.py
+++ b/autobahn/setup.py
@@ -153,7 +153,9 @@ setup(
         'compress': ["python-snappy>=0.5", "lz4>=0.2.1"],
 
         # needed if you want WAMPv2 binary serialization support
-        'serialization': ["msgpack-python>=0.4.0"]
+        'serialization': ["msgpack-python>=0.4.0"],
+
+        'dev': ["pep8", "flake8", "mock>=1.0.1"],
     },
     tests_require=test_requirements,
     cmdclass={'test': PyTest},

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -40,7 +40,7 @@ commands =
    trial --version
    trial autobahn
 basepython = python2.6
-install_command = pip install {packages} autobahn[twisted,serialization,dev]
+install_command = pip install {packages} autobahn[twisted,serialization]
 setenv =
    USE_TWISTED = 1
 
@@ -54,7 +54,7 @@ commands =
    python -V
    python -m pytest
 basepython = python2.6
-install_command = pip install {packages} autobahn[asyncio,serialization,dev]
+install_command = pip install {packages} autobahn[asyncio,serialization]
 setenv =
    USE_ASYNCIO = 1
 
@@ -67,7 +67,7 @@ commands =
    trial --version
    trial autobahn
 basepython = python2.7
-install_command = pip install {packages} autobahn[twisted,serialization,dev]
+install_command = pip install {packages} autobahn[twisted,serialization]
 setenv =
    USE_TWISTED = 1
 
@@ -78,7 +78,7 @@ commands =
    python -V
    python -m pytest
 basepython = python2.7
-install_command = pip install {packages} autobahn[asyncio,serialization,dev]
+install_command = pip install {packages} autobahn[asyncio,serialization]
 setenv =
    USE_ASYNCIO = 1
 
@@ -89,7 +89,7 @@ commands =
    python -V
    python -m pytest
 basepython = python3.3
-install_command = pip install {packages} autobahn[asyncio,serialization,dev]
+install_command = pip install {packages} autobahn[asyncio,serialization]
 setenv =
    USE_ASYNCIO = 1
 
@@ -100,7 +100,7 @@ commands =
    python -V
    python -m pytest
 basepython = python3.4
-install_command = pip install {packages} autobahn[asyncio,serialization,dev]
+install_command = pip install {packages} autobahn[asyncio,serialization]
 setenv =
    USE_ASYNCIO = 1
 
@@ -116,7 +116,7 @@ commands =
    trial --version
    trial autobahn
 basepython = pypy
-install_command = pip install {packages} autobahn[twisted,serialization,dev]
+install_command = pip install {packages} autobahn[twisted,serialization]
 setenv =
    USE_TWISTED = 1
 
@@ -127,6 +127,6 @@ commands =
    python -V
    python -m pytest
 basepython = pypy
-install_command = pip install {packages} autobahn[asyncio,serialization,dev]
+install_command = pip install {packages} autobahn[asyncio,serialization]
 setenv =
    USE_ASYNCIO = 1

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -10,7 +10,9 @@ envlist = flake8,
           pypy2asyncio
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    mock
 commands = python -m pytest
 whitelist_externals = sh
 
@@ -18,7 +20,6 @@ whitelist_externals = sh
 [testenv:flake8]
 deps =
    flake8
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -29,9 +30,9 @@ basepython = python2.7
 
 [testenv:py26twisted]
 deps =
+   {[testenv]deps}
    twisted
    unittest2
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -39,30 +40,26 @@ commands =
    trial --version
    trial autobahn
 basepython = python2.6
-install_command = pip install {packages} autobahn[twisted,serialization]
+install_command = pip install {packages} autobahn[twisted,serialization,dev]
 setenv =
    USE_TWISTED = 1
 
 
 [testenv:py26asyncio]
 deps =
-   pytest
+   {[testenv]deps}
    unittest2
-   mock
 commands =
    sh -c "which python"
    python -V
    python -m pytest
 basepython = python2.6
-install_command = pip install {packages} autobahn[asyncio,serialization]
+install_command = pip install {packages} autobahn[asyncio,serialization,dev]
 setenv =
    USE_ASYNCIO = 1
 
 
 [testenv:py27twisted]
-deps =
-   twisted
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -70,57 +67,48 @@ commands =
    trial --version
    trial autobahn
 basepython = python2.7
-install_command = pip install {packages} autobahn[twisted,serialization]
+install_command = pip install {packages} autobahn[twisted,serialization,dev]
 setenv =
    USE_TWISTED = 1
 
 
 [testenv:py27asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
    python -m pytest
 basepython = python2.7
-install_command = pip install {packages} autobahn[asyncio,serialization]
+install_command = pip install {packages} autobahn[asyncio,serialization,dev]
 setenv =
    USE_ASYNCIO = 1
 
 
 [testenv:py33asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
    python -m pytest
 basepython = python3.3
-install_command = pip install {packages} autobahn[asyncio,serialization]
+install_command = pip install {packages} autobahn[asyncio,serialization,dev]
 setenv =
    USE_ASYNCIO = 1
 
 
 [testenv:py34asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
    python -m pytest
 basepython = python3.4
-install_command = pip install {packages} autobahn[asyncio,serialization]
+install_command = pip install {packages} autobahn[asyncio,serialization,dev]
 setenv =
    USE_ASYNCIO = 1
 
 
 [testenv:pypy2twisted]
 deps =
+   {[testenv]deps}
    twisted
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -128,20 +116,17 @@ commands =
    trial --version
    trial autobahn
 basepython = pypy
-install_command = pip install {packages} autobahn[twisted,serialization]
+install_command = pip install {packages} autobahn[twisted,serialization,dev]
 setenv =
    USE_TWISTED = 1
 
 
 [testenv:pypy2asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
    python -m pytest
 basepython = pypy
-install_command = pip install {packages} autobahn[asyncio,serialization]
+install_command = pip install {packages} autobahn[asyncio,serialization,dev]
 setenv =
    USE_ASYNCIO = 1


### PR DESCRIPTION
This adds several unit-tests around subscribe() handling, simplifies the callback-invoking code, handles an error-case with duplicate subscription IDs and suggests a way to handle exceptions coming from "user"/callback code (but only covers the case of such an error in a publish() callback).