### PR TITLE
Callback exception handling

### DIFF
--- a/autobahn/autobahn/twisted/wamp.py
+++ b/autobahn/autobahn/twisted/wamp.py
@@ -86,13 +86,15 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
     WAMP application session for Twisted-based applications.
     """
 
-    def onUserError(self, e):
+    def onUserError(self, e, msg):
         """
         Override of wamp.ApplicationSession
         """
         # see docs; will print currently-active exception to the logs,
         # which is just what we want.
         log.err()
+        # also log the framework-provided error-message
+        log.err(msg)
 
 
 class ApplicationSessionFactory(FutureMixin, protocol.ApplicationSessionFactory):

--- a/autobahn/autobahn/twisted/wamp.py
+++ b/autobahn/autobahn/twisted/wamp.py
@@ -86,6 +86,14 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
     WAMP application session for Twisted-based applications.
     """
 
+    def onUserError(self, e):
+        """
+        Override of wamp.ApplicationSession
+        """
+        # see docs; will print currently-active exception to the logs,
+        # which is just what we want.
+        log.err()
+
 
 class ApplicationSessionFactory(FutureMixin, protocol.ApplicationSessionFactory):
     """

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -377,6 +377,18 @@ class ApplicationSession(BaseSession):
         else:
             raise Exception("transport disconnected")
 
+    def onUserError(self, e):
+        """
+        This is called when we try to fire a callback, but get an
+        exception from user code -- for example, a registered publish
+        callback or a registered method. Intended to be overridden in
+        the Twisted or asyncio ApplicationSession objects where proper
+        logging can be provided.
+
+        :param e: the Exception we caught.
+        """
+        pass
+
     def onMessage(self, msg):
         """
         Implements :func:`autobahn.wamp.interfaces.ITransportHandler.onMessage`

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import
 
+import traceback
 import inspect
 import six
 from six import StringIO
@@ -444,41 +445,25 @@ class ApplicationSession(BaseSession):
             elif isinstance(msg, message.Event):
 
                 if msg.subscription in self._subscriptions:
-
                     handler = self._subscriptions[msg.subscription]
-
                     if handler.details_arg:
                         if not msg.kwargs:
                             msg.kwargs = {}
                         msg.kwargs[handler.details_arg] = types.EventDetails(publication=msg.publication, publisher=msg.publisher, topic=msg.topic)
 
+                    invoke_args = (handler.obj,) if handler.obj else tuple()
+                    if msg.args:
+                        invoke_args = invoke_args + tuple(msg.args)
+                    invoke_kwargs = msg.kwargs if msg.kwargs else dict()
                     try:
-                        if handler.obj:
-                            if msg.kwargs:
-                                if msg.args:
-                                    handler.fn(handler.obj, *msg.args, **msg.kwargs)
-                                else:
-                                    handler.fn(handler.obj, **msg.kwargs)
-                            else:
-                                if msg.args:
-                                    handler.fn(handler.obj, *msg.args)
-                                else:
-                                    handler.fn(handler.obj)
-                        else:
-                            if msg.kwargs:
-                                if msg.args:
-                                    handler.fn(*msg.args, **msg.kwargs)
-                                else:
-                                    handler.fn(**msg.kwargs)
-                            else:
-                                if msg.args:
-                                    handler.fn(*msg.args)
-                                else:
-                                    handler.fn()
+                        handler.fn(*invoke_args, **invoke_kwargs)
 
                     except Exception as e:
+                        self.onUserError(e)
                         if self.debug_app:
-                            print("Failure while firing event handler {0} subscribed under '{1}' ({2}): {3}".format(handler.fn, handler.topic, msg.subscription, e))
+                            traceback.print_exc()
+                            print('While firing {0} subscribed under "{1}" ("{2}").'.format(
+                                handler.fn, handler.topic, msg.subscription))
 
                 else:
                     raise ProtocolError("EVENT received for non-subscribed subscription ID {0}".format(msg.subscription))
@@ -493,15 +478,20 @@ class ApplicationSession(BaseSession):
                     raise ProtocolError("PUBLISHED received for non-pending request ID {0}".format(msg.request))
 
             elif isinstance(msg, message.Subscribed):
-
                 if msg.request in self._subscribe_reqs:
                     d, obj, fn, topic, options = self._subscribe_reqs.pop(msg.request)
-                    if options:
-                        self._subscriptions[msg.subscription] = Handler(obj, fn, topic, options.details_arg)
-                    else:
-                        self._subscriptions[msg.subscription] = Handler(obj, fn, topic)
-                    s = Subscription(self, msg.subscription)
-                    self._resolve_future(d, s)
+                    sub_id = msg.subscription
+                    # we should NEVER have our ID subscribed already
+                    if sub_id in self._subscriptions:
+                        raise ProtocolError(
+                            'SUBSCRIBED received with existing subscription:' +
+                            str(sub_id) + ' (request ID "{0}").'.format(msg.request))
+
+                    details = options.details_arg if options else None
+                    handler = Handler(obj, fn, topic, details)
+                    self._subscriptions[sub_id] = handler
+                    self._resolve_future(d, Subscription(self, sub_id))
+
                 else:
                     raise ProtocolError("SUBSCRIBED received for non-pending request ID {0}".format(msg.request))
 
@@ -851,6 +841,9 @@ class ApplicationSession(BaseSession):
                         uri = pat.uri()
                         subopts = options or pat.subscribe_options()
                         dl.append(_subscribe(handler, proc, uri, subopts))
+            # XXX pretty sure we *don't* want consome_exceptions here,
+            # because we don't ourselves check the returned list for
+            # errors.
             return self._gather_futures(dl, consume_exceptions=True)
 
     def _unsubscribe(self, subscription):

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -489,13 +489,13 @@ class ApplicationSession(BaseSession):
                     d, obj, fn, topic, options = self._subscribe_reqs.pop(msg.request)
                     if msg.subscription in self._subscriptions:
                         existing = self._subscriptions[msg.subscription]
+                        sub_id = existing[0].subscription_id
                         # the topics should match
                         if existing[0].topic != topic:
                             raise ProtocolError(
                                 'SUBSCRIBED for ID "{0}" should have topic "{1}" not "{2}".'.format(
                                     sub_id, existing.topic, topic))
 
-                        sub_id = existing[0].subscription_id
                     else:
                         sub_id = msg.subscription
                         self._subscriptions[msg.subscription] = []

--- a/autobahn/autobahn/wamp/protocol.py
+++ b/autobahn/autobahn/wamp/protocol.py
@@ -468,7 +468,7 @@ class ApplicationSession(BaseSession):
                             handler.fn(*invoke_args, **invoke_kwargs)
 
                         except Exception as e:
-                            msg = 'While firing {} subscribed under "{}" ("{}").'.format(
+                            msg = 'While firing {0} subscribed under "{1}" ("{2}").'.format(
                                 handler.fn, handler.topic, msg.subscription)
                             self.onUserError(e, msg)
 

--- a/autobahn/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/autobahn/wamp/test/test_protocol.py
@@ -31,7 +31,7 @@ import os
 if os.environ.get('USE_TWISTED', False):
 
     from six import StringIO
-    from mock import Mock, patch
+    from mock import Mock
     from twisted.trial import unittest
     # import unittest
 
@@ -41,7 +41,7 @@ if os.environ.get('USE_TWISTED', False):
     from autobahn.wamp import serializer
     from autobahn.wamp import role
     from autobahn import util
-    from autobahn.wamp.exception import ApplicationError, NotAuthorized, InvalidUri
+    from autobahn.wamp.exception import ApplicationError, NotAuthorized, InvalidUri, ProtocolError
     from autobahn.wamp import types
 
     from autobahn.twisted.wamp import ApplicationSession
@@ -54,7 +54,6 @@ if os.environ.get('USE_TWISTED', False):
             self._serializer = serializer.JsonSerializer()
             self._registrations = {}
             self._invocations = {}
-            self._topic_subscriptions = {}
 
             self._handler.onOpen(self)
 
@@ -106,14 +105,7 @@ if os.environ.get('USE_TWISTED', False):
                     reply = message.Result(request, args=msg.args, kwargs=msg.kwargs)
 
             elif isinstance(msg, message.Subscribe):
-                # fake out that we can do duplicate subscriptions to
-                # the same topic
-                if msg.topic in self._topic_subscriptions:
-                    reply_id = self._topic_subscriptions[msg.topic]
-                else:
-                    reply_id = util.id()
-                    self._topic_subscriptions[msg.topic] = reply_id
-                reply = message.Subscribed(msg.request, reply_id)
+                reply = message.Subscribed(msg.request, util.id())
 
             elif isinstance(msg, message.Unsubscribe):
                 reply = message.Unsubscribed(msg.request)
@@ -263,27 +255,120 @@ if os.environ.get('USE_TWISTED', False):
             event0 = Deferred()
             event1 = Deferred()
 
-            subscription0 = yield handler.subscribe(lambda: event0.callback(42), u'com.myapp.topic1')
-            subscription1 = yield handler.subscribe(lambda: event1.callback('foo'), u'com.myapp.topic1')
-            # same topic, *HAS* to be the same ID for protocol to
-            # work, because "EVENT, SUBSCRIBED.Subscription|id" is the
-            # only way to send one.
-            self.assertTrue(subscription0.id == subscription1.id)
+            subscription0 = yield handler.subscribe(
+                lambda: event0.callback(42), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                lambda: event1.callback('foo'), u'com.myapp.topic1')
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
 
-            # do a publish, and then fake the acknowledgement message
+            # do a publish (MockTransport fakes the acknowledgement
+            # message) and then do an actual publish event
+            # it would be up to the router (broker) to send out
+            # multiple Events when appropriate, so we do that here
             publish = yield handler.publish(
                 u'com.myapp.topic1',
                 options=types.PublishOptions(acknowledge=True, exclude_me=False),
             )
-            msg = message.Event(subscription0.id, publish.id)
-            handler.onMessage(msg)
+            handler.onMessage(message.Event(subscription0.id, publish.id))
+            handler.onMessage(message.Event(subscription1.id, publish.id))
 
-            # ensure that the publish "did the right thing" and called
-            # both callbacks
-            self.assertTrue(event0.called, "Didn't get first subscribe's callback")
-            self.assertTrue(event1.called, "Didn't get second subscribe's callback")
+            # ensure we actually got both callbacks
+            self.assertTrue(event0.called, "Missing callback")
+            self.assertTrue(event1.called, "Missing callback")
 
+        @inlineCallbacks
+        def test_double_subscribe_single_unsubscribe(self):
+            '''
+            Make sure we correctly deal with unsubscribing one of our handlers
+            from the same topic.
+            '''
+            handler = ApplicationSession()
+            MockTransport(handler)
 
+            event0 = Deferred()
+            event1 = Deferred()
+
+            subscription0 = yield handler.subscribe(
+                lambda: event0.callback(42), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                lambda: event1.callback('foo'), u'com.myapp.topic1')
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
+            yield subscription1.unsubscribe()
+
+            # do a publish (MockTransport fakes the acknowledgement
+            # message) and then do an actual publish event
+            # it would be up to the router (broker) to send out
+            # multiple Events when appropriate, so we do that here
+            publish = yield handler.publish(
+                u'com.myapp.topic1',
+                options=types.PublishOptions(acknowledge=True, exclude_me=False),
+            )
+            handler.onMessage(message.Event(subscription0.id, publish.id))
+            try:
+                handler.onMessage(message.Event(subscription1.id, publish.id))
+                self.fail("Should get exception for unsubscribed topic")
+            except ProtocolError as e:
+                pass
+
+            # since we unsubscribed the second event handler, we
+            # should NOT have called its callback
+            self.assertTrue(event0.called, "Missing callback")
+            self.assertTrue(not event1.called, "Second callback fired.")
+
+        @inlineCallbacks
+        def test_double_subscribe_errors(self):
+            """
+            Test various error-conditions when we try to add a second
+            subscription-handler (its signature must match any
+            existing handlers).
+            """
+            handler = ApplicationSession()
+            MockTransport(handler)
+
+            event0 = Deferred()
+            event1 = Deferred()
+
+            def second(*args, **kw):
+                # our EventDetails should have been passed as the
+                # "boom" kwarg; see "details_arg=" below
+                self.assertTrue('boom' in kw)
+                self.assertTrue(isinstance(kw['boom'], types.EventDetails))
+                event1.callback(args)
+
+            subscription0 = yield handler.subscribe(
+                lambda arg: event0.callback(arg), u'com.myapp.topic1')
+            subscription1 = yield handler.subscribe(
+                second, u'com.myapp.topic1',
+                types.SubscribeOptions(details_arg='boom'),
+            )
+            # the IDs should be different, even if the topic is the same
+            self.assertTrue(subscription0.id != subscription1.id)
+
+            # MockTransport gives us the ack reply and then we do our
+            # own event messages. We need two, since it would be up to
+            # a Router/Broker to correctly hand out two Event messages
+            # if two callbacks are registered for the same topic
+            # string
+            publish = yield handler.publish(
+                u'com.myapp.topic1',
+                options=types.PublishOptions(acknowledge=True, exclude_me=False),
+            )
+            # note that the protocol serializer converts all sequences
+            # to lists, so we pass "args" as a list, not a tuple on
+            # purpose.
+            handler.onMessage(
+                message.Event(subscription0.id, publish.id, args=['arg0']))
+            handler.onMessage(
+                message.Event(subscription1.id, publish.id, args=['arg0']))
+
+            # each callback should have gotten called, each with its
+            # own args (we check the correct kwarg in second() above)
+            self.assertTrue(event0.called)
+            self.assertTrue(event1.called)
+            self.assertEqual(event0.result, 'arg0')
+            self.assertEqual(event1.result, ('arg0',))
 
         @inlineCallbacks
         def test_publish_callback_exception(self):
@@ -305,6 +390,7 @@ if os.environ.get('USE_TWISTED', False):
             sys.stdout = StringIO()
             try:
                 error_instance = RuntimeError("we have a problem")
+
                 def boom():
                     raise error_instance
 

--- a/autobahn/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/autobahn/wamp/test/test_protocol.py
@@ -337,11 +337,11 @@ if os.environ.get('USE_TWISTED', False):
 
             # monkey-patch ApplicationSession to ensure we get our message
             unsubscribed_d = Deferred()
+
             def onMessage(msg):
                 if isinstance(msg, message.Unsubscribed):
                     unsubscribed_d.callback(msg)
                 return ApplicationSession.onMessage(handler, msg)
-
             handler.onMessage = onMessage
 
             event0 = Deferred()
@@ -371,7 +371,7 @@ if os.environ.get('USE_TWISTED', False):
             try:
                 handler.onMessage(message.Event(subscription0.id, publish.id))
                 self.fail("Expected ProtocolError")
-            except ProtocolError as e:
+            except ProtocolError:
                 pass
 
             # since we unsubscribed the second event handler, we

--- a/autobahn/setup.py
+++ b/autobahn/setup.py
@@ -155,7 +155,7 @@ setup(
         # needed if you want WAMPv2 binary serialization support
         'serialization': ["msgpack-python>=0.4.0"],
 
-        'dev': ["pep8", "flake8", "mock>=1.0.1"],
+        'dev': ["pep8", "flake8", "mock>=1.0.1", "pytest>=2.6.4"],
     },
     tests_require=test_requirements,
     cmdclass={'test': PyTest},

--- a/autobahn/setup.py
+++ b/autobahn/setup.py
@@ -153,7 +153,9 @@ setup(
         'compress': ["python-snappy>=0.5", "lz4>=0.2.1"],
 
         # needed if you want WAMPv2 binary serialization support
-        'serialization': ["msgpack-python>=0.4.0"]
+        'serialization': ["msgpack-python>=0.4.0"],
+
+        'dev': ["pep8", "flake8", "mock>=1.0.1"],
     },
     tests_require=test_requirements,
     cmdclass={'test': PyTest},

--- a/autobahn/tox.ini
+++ b/autobahn/tox.ini
@@ -10,7 +10,9 @@ envlist = flake8,
           pypy2asyncio
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    mock
 commands = python -m pytest
 whitelist_externals = sh
 
@@ -18,7 +20,6 @@ whitelist_externals = sh
 [testenv:flake8]
 deps =
    flake8
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -29,9 +30,9 @@ basepython = python2.7
 
 [testenv:py26twisted]
 deps =
+   {[testenv]deps}
    twisted
    unittest2
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -46,9 +47,8 @@ setenv =
 
 [testenv:py26asyncio]
 deps =
-   pytest
+   {[testenv]deps}
    unittest2
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -60,9 +60,6 @@ setenv =
 
 
 [testenv:py27twisted]
-deps =
-   twisted
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -76,9 +73,6 @@ setenv =
 
 
 [testenv:py27asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -90,9 +84,6 @@ setenv =
 
 
 [testenv:py33asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -104,9 +95,6 @@ setenv =
 
 
 [testenv:py34asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V
@@ -119,8 +107,8 @@ setenv =
 
 [testenv:pypy2twisted]
 deps =
+   {[testenv]deps}
    twisted
-   mock
 commands =
    sh -c "which python"
    sh -c "which trial"
@@ -134,9 +122,6 @@ setenv =
 
 
 [testenv:pypy2asyncio]
-deps =
-   pytest
-   mock
 commands =
    sh -c "which python"
    python -V


### PR DESCRIPTION
This adds several unit-tests around subscribe() handling, simplifies the callback-invoking code, handles an error-case with duplicate subscription IDs and suggests a way to handle exceptions coming from "user"/callback code (but only covers the case of such an error in a publish() callback).

Note this is a re-squashed version of #352 after I got Travis-CI to be happy.