### PR TITLE
More error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,13 @@ test_twisted:
 	USE_TWISTED=1 trial autobahn
 	#WAMP_ROUTER_URL="ws://127.0.0.1:8080/ws" USE_TWISTED=1 trial autobahn
 
+test_twisted_coverage:
+	-rm .coverage
+	USE_TWISTED=1 coverage run --omit=*/test/* --source=autobahn `which trial` autobahn
+#	coverage -a -d annotated_coverage
+	coverage html
+	coverage report --show-missing
+
 # test under asyncio
 test_asyncio:
 	USE_ASYNCIO=1 python -m pytest -rsx

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import
 
+import sys
+
 from autobahn.wamp import protocol
 from autobahn.wamp.types import ComponentConfig
 from autobahn.websocket.protocol import parseWsUrl
@@ -102,9 +104,12 @@ class FutureMixin(object):
         def done(f):
             try:
                 res = f.result()
-                callback(res)
-            except Exception as e:
-                errback(e)
+                if callback:
+                    callback(res)
+            except:
+                typ, exc, tb = sys.exc_info()
+                if errback:
+                    errback(typ, exc, tb)
         return future.add_done_callback(done)
 
     @staticmethod

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -30,6 +30,7 @@ import sys
 import inspect
 
 from twisted.python import log
+from twisted.python.failure import Failure
 from twisted.application import service
 from twisted.internet.defer import Deferred, \
     maybeDeferred, \
@@ -84,7 +85,29 @@ class FutureMixin(object):
 
     @staticmethod
     def _add_future_callbacks(future, callback, errback):
-        return future.addCallbacks(callback, errback)
+        # callback and/or errback may be None
+
+        # Note that errback takes 3 args: type, exception, tb our
+        # errbacks can be consistent between Twisted and asyncio.
+
+        # alternatively: what if we made a dummy Failure-like thing
+        # for asyncio so our "standard" errback in protocol.py could
+        # use the Failure API, or at least the bits we need...like
+        # collecting the traceback frames.
+
+        def _errback(fail):
+            # converting to common API between asyncio/Twisted
+            return errback(fail.type, fail.value, fail.tb)
+
+        if callback is None:
+            assert errback is not None
+            future.addErrback(_errback)
+        elif errback is None:
+            future.addCallback(callback)
+        else:
+            future.addCallbacks(callback, _errback)
+
+        return future
 
     @staticmethod
     def _gather_futures(futures, consume_exceptions=True):
@@ -96,15 +119,14 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
     WAMP application session for Twisted-based applications.
     """
 
-    def onUserError(self, e, msg):
+    def onUserError(self, typ, exc, tb, msg=None):
         """
         Override of wamp.ApplicationSession
         """
-        # see docs; will print currently-active exception to the logs,
-        # which is just what we want.
-        log.err()
-        # also log the framework-provided error-message
-        log.err(msg)
+        log.err(Failure(exc, typ, tb))
+        # also log the framework-provided error-message, if any
+        if msg:
+            log.err(msg)
 
 
 class ApplicationSessionFactory(FutureMixin, protocol.ApplicationSessionFactory):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -123,10 +123,10 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
         """
         Override of wamp.ApplicationSession
         """
-        log.err(Failure(exc, typ, tb))
-        # also log the framework-provided error-message, if any
         if msg:
-            log.err(msg)
+            log.err(Failure(exc, typ, tb), msg)
+        else:
+            log.err(Failure(exc, typ, tb))
 
 
 class ApplicationSessionFactory(FutureMixin, protocol.ApplicationSessionFactory):

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -262,7 +262,10 @@ class ISession(object):
     @abc.abstractmethod
     def onConnect(self):
         """
-        Callback fired when the transport this session will run over has been established.
+        Callback fired when the transport this session will run over has
+        been established.
+
+        May return a Deferred/Future.
         """
 
     @abc.abstractmethod
@@ -276,6 +279,8 @@ class ISession(object):
         """
         Callback fired when the peer demands authentication.
 
+        May return a Deferred/Future.
+
         :param challenge: The authentication challenge.
         :type challenge: Instance of :class:`autobahn.wamp.types.Challenge`.
         """
@@ -284,6 +289,8 @@ class ISession(object):
     def onJoin(self, details):
         """
         Callback fired when WAMP session has been established.
+
+        May return a Deferred/Future.
 
         :param details: Session information.
         :type details: Instance of :class:`autobahn.wamp.types.SessionDetails`.
@@ -306,6 +313,8 @@ class ISession(object):
         """
         Callback fired when WAMP session has is closed
 
+        May return a Deferred/Future.
+
         :param details: Close information.
         :type details: Instance of :class:`autobahn.wamp.types.CloseDetails`.
         """
@@ -320,6 +329,9 @@ class ISession(object):
     def onDisconnect(self):
         """
         Callback fired when underlying transport has been closed.
+
+        May return a Deferred/Future (but note that the underlying
+        transport is already gone).
         """
 
     @abc.abstractmethod

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -638,8 +638,9 @@ class ApplicationSession(BaseSession):
                         try:
                             handler.fn(*invoke_args, **invoke_kwargs)
                         except:
-                            errmsg = 'While firing {0} subscribed under "{1}".'.format(
-                                handler.fn, msg.topic)
+                            errmsg = 'While firing {0}'.format(handler.fn)
+                            if msg.topic is not None:
+                                errmsg += ' (subscribed under "{0}")'.format(msg.topic)
                             try:
                                 self.onUserError(*sys.exc_info(), msg=errmsg)
                             except:

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -384,8 +384,10 @@ class BaseSession(object):
                     else:
                         exc = ecls()
             except Exception:
-                # XXX uncovered
-                self.onUserError(*sys.exc_info(), msg="While re-constructing exception")
+                try:
+                    self.onUserError(*sys.exc_info(), msg="While re-constructing exception")
+                except:
+                    pass
 
         if not exc:
             # the following ctor never fails ..
@@ -532,7 +534,10 @@ class ApplicationSession(BaseSession):
         will do for both Future and Deferred
         '''
         # print("_swallow_error", typ, exc, tb)
-        self.onUserError(typ, exc, tb, msg=msg)
+        try:
+            self.onUserError(typ, exc, tb, msg=msg)
+        except:
+            pass
         return None
 
     def onMessage(self, msg):
@@ -709,7 +714,10 @@ class ApplicationSession(BaseSession):
                                 # XXX what if on_progress returns a Deferred/Future?
                                 call_request.options.on_progress(*args, **kw)
                             except:
-                                self.onUserError(*sys.exc_info(), msg="While firing onProgress")
+                                try:
+                                    self.onUserError(*sys.exc_info(), msg="While firing on_progress")
+                                except:
+                                    pass
 
                         else:
                             # silently ignore progressive results
@@ -834,7 +842,10 @@ class ApplicationSession(BaseSession):
                         self._invocations[msg.request].cancel()
                     except:
                         # XXX can .cancel() return a Deferred/Future?
-                        self.onUserError(*sys.exc_info(), msg="While cancelling call.")
+                        try:
+                            self.onUserError(*sys.exc_info(), msg="While cancelling call.")
+                        except:
+                            pass
                     finally:
                         del self._invocations[msg.request]
 

--- a/autobahn/wamp/test/test_user_handler_errors.py
+++ b/autobahn/wamp/test/test_user_handler_errors.py
@@ -1,0 +1,385 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+import os
+
+if os.environ.get('USE_TWISTED', False):
+    from twisted.trial import unittest
+    from twisted.internet import defer
+    from twisted.python.failure import Failure
+    from autobahn.wamp import message, role
+    from autobahn.wamp.exception import ProtocolError
+    from autobahn.twisted.wamp import ApplicationSession
+
+    class MockTransport:
+        def __init__(self):
+            self.messages = []
+
+        def send(self, msg):
+            self.messages.append(msg)
+
+        def close(self, *args, **kw):
+            pass
+
+    class MockApplicationSession(ApplicationSession):
+        '''
+        This is used by tests, which typically attach their own handler to
+        on*() methods. This just collects any errors from onUserError
+        '''
+
+        def __init__(self, *args, **kw):
+            ApplicationSession.__init__(self, *args, **kw)
+            self.errors = []
+            self._transport = MockTransport()
+
+        def onUserError(self, typ, exc, tb, msg):
+            self.errors.append((typ, exc, tb, msg))
+
+    def exception_raiser(exc):
+        '''
+        Create a method that takes any args and always raises the given
+        Exception instance.
+        '''
+        assert isinstance(exc, Exception), "Must derive from Exception"
+
+        def method(*args, **kw):
+            raise exc
+        return method
+
+    def async_exception_raiser(exc):
+        '''
+        Create a method that takes any args, and always returns a Deferred
+        that has failed.
+        '''
+        assert isinstance(exc, Exception), "Must derive from Exception"
+
+        def method(*args, **kw):
+            try:
+                raise exc
+            except:
+                return defer.fail(Failure())
+        return method
+
+    def create_mock_welcome():
+        return message.Welcome(
+            1234,
+            {
+                u'broker': role.RoleBrokerFeatures(),
+            },
+        )
+
+    class TestSessionCallbacks(unittest.TestCase):
+        '''
+        These test that callbacks on user-overridden ApplicationSession
+        methods that produce errors are handled correctly.
+
+        XXX should do state-diagram documenting where we are when each
+        of these cases arises :/
+        '''
+
+        # XXX sure would be nice to use py.test @fixture to do the
+        # async/sync exception-raising stuff (i.e. make each test run
+        # twice)...but that would mean switching all test-running over
+        # to py-test
+
+        def test_on_join(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("blammo")
+            session.onJoin = exception_raiser(exception)
+            msg = create_mock_welcome()
+
+            # give the sesion a WELCOME, from which it should call onJoin
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_join_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("blammo")
+            session.onJoin = async_exception_raiser(exception)
+            msg = create_mock_welcome()
+
+            # give the sesion a WELCOME, from which it should call onJoin
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            # import traceback
+            # traceback.print_exception(*session.errors[0][:3])
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_leave(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("boom")
+            session.onLeave = exception_raiser(exception)
+            msg = message.Abort(u"testing")
+
+            # we haven't done anything, so this is "abort before we've
+            # connected"
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_leave_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("boom")
+            session.onLeave = async_exception_raiser(exception)
+            msg = message.Abort(u"testing")
+
+            # we haven't done anything, so this is "abort before we've
+            # connected"
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_leave_valid_session(self):
+            '''
+            cover when onLeave called after we have a valid session
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onLeave = exception_raiser(exception)
+            # we have to get to an established connection first...
+            session.onMessage(create_mock_welcome())
+            self.assertTrue(session._session_id is not None)
+
+            # okay we have a session ("because ._session_id is not None")
+            msg = message.Goodbye()
+            session.onMessage(msg)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_leave_valid_session_deferred(self):
+            '''
+            cover when onLeave called after we have a valid session
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onLeave = async_exception_raiser(exception)
+            # we have to get to an established connection first...
+            session.onMessage(create_mock_welcome())
+            self.assertTrue(session._session_id is not None)
+
+            # okay we have a session ("because ._session_id is not None")
+            msg = message.Goodbye()
+            session.onMessage(msg)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_disconnect_via_close(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("sideways")
+            session.onDisconnect = exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_disconnect_via_close_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("sideways")
+            session.onDisconnect = async_exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        # XXX FIXME Probably more ways to call onLeave!
+
+        def test_on_challenge(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onChallenge = exception_raiser(exception)
+            msg = message.Challenge(u"foo")
+
+            # execute
+            session.onMessage(msg)
+
+            # we already handle any onChallenge errors as "abort the
+            # connection". So make sure our error showed up in the
+            # fake-transport.
+            self.assertEqual(0, len(session.errors))
+            self.assertEqual(1, len(session._transport.messages))
+            reply = session._transport.messages[0]
+            self.assertIsInstance(reply, message.Abort)
+            self.assertEqual("such challenge", reply.message)
+
+        def test_on_challenge_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onChallenge = async_exception_raiser(exception)
+            msg = message.Challenge(u"foo")
+
+            # execute
+            session.onMessage(msg)
+
+            # we already handle any onChallenge errors as "abort the
+            # connection". So make sure our error showed up in the
+            # fake-transport.
+            self.assertEqual(0, len(session.errors))
+            self.assertEqual(1, len(session._transport.messages))
+            reply = session._transport.messages[0]
+            self.assertIsInstance(reply, message.Abort)
+            self.assertEqual("such challenge", reply.message)
+
+        def test_no_session(self):
+            '''
+            test "all other cases" when we don't yet have a session
+            established, which should all raise ProtocolErrors and
+            *not* go through the onUserError handler. We cheat and
+            just test one.
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onConnect = exception_raiser(exception)
+
+            for msg in [message.Goodbye()]:
+                self.assertRaises(ProtocolError, session.onMessage, (msg,))
+            self.assertEqual(0, len(session.errors))
+
+        def test_on_disconnect(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("oh sadness")
+            session.onDisconnect = exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_disconnect_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("oh sadness")
+            session.onDisconnect = async_exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_disconnect_with_session(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onDisconnect = exception_raiser(exception)
+            # create a valid session
+            session.onMessage(create_mock_welcome())
+
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(2, len(session.errors))
+            # might want to re-think this?
+            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][1]))
+            self.assertEqual(exception, session.errors[1][1])
+
+        def test_on_disconnect_with_session_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onDisconnect = async_exception_raiser(exception)
+            # create a valid session
+            session.onMessage(create_mock_welcome())
+
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(2, len(session.errors))
+            # might want to re-think this?
+            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][1]))
+            self.assertEqual(exception, session.errors[1][1])
+
+        def test_on_connect(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onConnect = exception_raiser(exception)
+            trans = MockTransport()
+
+            # normally would be called from a Protocol?
+            session.onOpen(trans)
+
+            # shouldn't have done the .join()
+            self.assertEqual(0, len(trans.messages))
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        def test_on_connect_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onConnect = async_exception_raiser(exception)
+            trans = MockTransport()
+
+            # normally would be called from a Protocol?
+            session.onOpen(trans)
+
+            # shouldn't have done the .join()
+            self.assertEqual(0, len(trans.messages))
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][1])
+
+        # XXX likely missing other ways to invoke the above. need to
+        # cover, for sure:
+        #
+        # onChallenge
+        # onJoin
+        # onLeave
+        # onDisconnect
+        #
+        # what about other ISession ones?
+        # onConnect
+        # onDisconnect
+
+        # NOTE: for Event stuff, that is publish() handlers,
+        # test_publish_callback_exception in test_protocol.py already
+        # covers exceptions coming from user-code.

--- a/doc/work/programming.rst
+++ b/doc/work/programming.rst
@@ -330,7 +330,7 @@ Call a remote procedure which produces interim, progressive results:
       print("{} items deleted so far ..".format(n))
 
    total = yield session.call("com.myapp.log.delete",
-                              options = CallOptions(onProgress = deletedSoFar))
+                              options = CallOptions(on_progress = deletedSoFar))
    print("{} items deleted in total.".format(total))
 
 Distributed calls
@@ -524,7 +524,7 @@ and can be called like this
       print("{} items processed so far ..".format(i))
 
    total = yield session.call("com.myapp.longop", 10,
-                              options = CallOptions(onProgress = processedSoFar))
+                              options = CallOptions(on_progress = processedSoFar))
    print("{} items deleted in total.".format(total))
 
 Registration with invocation details

--- a/examples/asyncio/wamp/basic/rpc/progress/frontend.py
+++ b/examples/asyncio/wamp/basic/rpc/progress/frontend.py
@@ -46,7 +46,7 @@ class Component(ApplicationSession):
         def on_progress(i):
             print("Progress: {}".format(i))
 
-        res = yield from self.call('com.myapp.longop', 3, options=CallOptions(onProgress=on_progress))
+        res = yield from self.call('com.myapp.longop', 3, options=CallOptions(on_progress=on_progress))
 
         print("Final: {}".format(res))
 

--- a/examples/twisted/wamp/basic/rpc/progress/frontend.py
+++ b/examples/twisted/wamp/basic/rpc/progress/frontend.py
@@ -44,7 +44,7 @@ class Component(ApplicationSession):
         def on_progress(i):
             print("Progress: {}".format(i))
 
-        res = yield self.call('com.myapp.longop', 3, options=CallOptions(onProgress=on_progress))
+        res = yield self.call('com.myapp.longop', 3, options=CallOptions(on_progress=on_progress))
 
         print("Final: {}".format(res))
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist = flake8,
 deps =
     pytest
     mock
+    coverage
 commands = python -m pytest
 whitelist_externals = sh
 
@@ -63,9 +64,14 @@ setenv =
 commands =
    sh -c "which python"
    sh -c "which trial"
+   sh -c "which coverage"
    python -V
-   trial --version
-   trial autobahn
+   coverage --version
+   {envbindir}/trial --version
+   # XXX should probably add --branch
+   coverage run --source=autobahn --omit=*test* {envbindir}/trial autobahn
+   coverage report --show-missing
+   coverage html
 basepython = python2.7
 install_command = pip install {packages} autobahn[twisted,serialization]
 setenv =


### PR DESCRIPTION
This includes unit-tests and fixes for:

 - consistently handle async returns from onLeave etc methods
 - usable, consistent errback API between asyncio/Twisted
 - test-coverage for user-code raising errors
 - test-coverage for exceptions from invoked methods
 - on_progress used consistently everywhere
 - test-coverage for happy-path + exceptions in on_progress handlers