### PR TITLE
Sync and async error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,13 @@ test_twisted:
 	USE_TWISTED=1 trial autobahn
 	#WAMP_ROUTER_URL="ws://127.0.0.1:8080/ws" USE_TWISTED=1 trial autobahn
 
+test_twisted_coverage:
+	-rm .coverage
+	USE_TWISTED=1 coverage run --omit=*/test/* --source=autobahn `which trial` autobahn
+#	coverage -a -d annotated_coverage
+	coverage html
+	coverage report --show-missing
+
 # test under asyncio
 test_asyncio:
 	USE_ASYNCIO=1 python -m pytest -rsx

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -102,9 +102,11 @@ class FutureMixin(object):
         def done(f):
             try:
                 res = f.result()
-                callback(res)
+                if callback:
+                    callback(res)
             except Exception as e:
-                errback(e)
+                if errback:
+                    errback(e)
         return future.add_done_callback(done)
 
     @staticmethod

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -84,7 +84,14 @@ class FutureMixin(object):
 
     @staticmethod
     def _add_future_callbacks(future, callback, errback):
-        return future.addCallbacks(callback, errback)
+        # callback and/or errback may be None
+        if callback is None:
+            assert errback is not None
+            future.addErrback(errback)
+            return future
+        else:
+            future.addCallbacks(callback, errback)
+            return future
 
     @staticmethod
     def _gather_futures(futures, consume_exceptions=True):
@@ -102,7 +109,7 @@ class ApplicationSession(FutureMixin, protocol.ApplicationSession):
         """
         # see docs; will print currently-active exception to the logs,
         # which is just what we want.
-        log.err()
+        log.err(e)
         # also log the framework-provided error-message
         log.err(msg)
 

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -276,6 +276,8 @@ class ISession(object):
         """
         Callback fired when the peer demands authentication.
 
+        May return a Deferred/Future.
+
         :param challenge: The authentication challenge.
         :type challenge: Instance of :class:`autobahn.wamp.types.Challenge`.
         """
@@ -284,6 +286,8 @@ class ISession(object):
     def onJoin(self, details):
         """
         Callback fired when WAMP session has been established.
+
+        May return a Deferred/Future.
 
         :param details: Session information.
         :type details: Instance of :class:`autobahn.wamp.types.SessionDetails`.

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -698,23 +698,13 @@ class ApplicationSession(BaseSession):
                     if msg.progress:
 
                         # progressive result
-                        #
                         call_request = self._call_reqs[msg.request]
-
-                        on_progress = call_request.options.onProgress
-
-                        if on_progress:
+                        if call_request.options.on_progress:
+                            kw = msg.kwargs or dict()
+                            args = msg.args or tuple()
                             try:
-                                if msg.kwargs:
-                                    if msg.args:
-                                        on_progress(*msg.args, **msg.kwargs)
-                                    else:
-                                        on_progress(**msg.kwargs)
-                                else:
-                                    if msg.args:
-                                        on_progress(*msg.args)
-                                    else:
-                                        on_progress()
+                                # XXX what if on_progress returns a Deferred/Future?
+                                call_request.options.on_progress(*args, **kw)
                             except Exception as e:
                                 try:
                                     self.onUserError(e, "While firing on_progress")

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -486,7 +486,8 @@ class ApplicationSession(BaseSession):
         if self._transport:
             self._transport.close()
         else:
-            raise Exception("transport disconnected")
+            # XXX or shall we just ignore this?
+            raise RuntimeError("No transport, but disconnect() called.")
 
     def onUserError(self, e, msg):
         """
@@ -546,7 +547,7 @@ class ApplicationSession(BaseSession):
                 raise ProtocolError("Received {0} message, and session is not yet established".format(msg.__class__))
 
         else:
-
+            # self._session_id != None (aka "session established")
             if isinstance(msg, message.Goodbye):
                 if not self._goodbye_sent:
                     # the peer wants to close: send GOODBYE reply
@@ -772,9 +773,8 @@ class ApplicationSession(BaseSession):
                             else:
                                 tb = None
 
-                            if self.debug_app:
-                                print("Failure while invoking procedure {0} registered under '{1}' ({2}):".format(endpoint.fn, endpoint.procedure, msg.registration))
-                                print(err)
+                            errmsg = "Failure while invoking procedure {0} registered under '{1}' ({2}):".format(endpoint.fn, endpoint.procedure, msg.registration)
+                            self.onUserError(e, msg=errmsg)
 
                             del self._invocations[msg.request]
 

--- a/autobahn/wamp/test/test_user_handler_errors.py
+++ b/autobahn/wamp/test/test_user_handler_errors.py
@@ -1,0 +1,401 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+import os
+
+if os.environ.get('USE_TWISTED', False):
+    from twisted.trial import unittest
+    from twisted.internet import defer
+    from twisted.python.failure import Failure
+    from autobahn.wamp import message, role
+    from autobahn.wamp.exception import ProtocolError
+    from autobahn.twisted.wamp import ApplicationSession
+
+    class MockTransport:
+        def __init__(self):
+            self.messages = []
+
+        def send(self, msg):
+            self.messages.append(msg)
+
+        def close(self, *args, **kw):
+            pass
+
+    class MockApplicationSession(ApplicationSession):
+        '''
+        This is used by tests, which typically attach their own handler to
+        on*() methods. This just collects any errors from onUserError
+        '''
+
+        def __init__(self, *args, **kw):
+            ApplicationSession.__init__(self, *args, **kw)
+            self.errors = []
+            self._transport = MockTransport()
+
+        def onUserError(self, e, msg):
+            self.errors.append((e, msg))
+
+    def exception_raiser(exc):
+        '''
+        Create a method that takes any args and always raises the given
+        Exception instance.
+        '''
+        assert isinstance(exc, Exception), "Must derive from Exception"
+
+        def method(*args, **kw):
+            raise exc
+        return method
+
+    def async_exception_raiser(exc):
+        '''
+        Create a method that takes any args, and always returns a Deferred
+        that has failed.
+        '''
+        assert isinstance(exc, Exception), "Must derive from Exception"
+
+        def method(*args, **kw):
+            try:
+                raise exc
+            except:
+                return defer.fail(Failure())
+        return method
+
+    def create_mock_welcome():
+        return message.Welcome(
+            1234,
+            {
+                u'broker': role.RoleBrokerFeatures(),
+            },
+        )
+
+    class TestSessionCallbacks(unittest.TestCase):
+        '''
+        These test that callbacks on user-overridden ApplicationSession
+        methods that produce errors are handled correctly.
+
+        XXX should do state-diagram documenting where we are when each
+        of these cases arises :/
+        '''
+
+        # XXX sure would be nice to use py.test @fixture to do the
+        # async/sync exception-raising stuff (i.e. make each test run
+        # twice)...but that would mean switching all test-running over
+        # to py-test
+
+        def test_on_join(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("blammo")
+            session.onJoin = exception_raiser(exception)
+            msg = create_mock_welcome()
+
+            # give the sesion a WELCOME, from which it should call onJoin
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_join_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("blammo")
+            session.onJoin = async_exception_raiser(exception)
+            msg = create_mock_welcome()
+
+            # give the sesion a WELCOME, from which it should call onJoin
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            # import traceback
+            # traceback.print_exception(*session.errors[0][:3])
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_leave(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("boom")
+            session.onLeave = exception_raiser(exception)
+            msg = message.Abort(u"testing")
+
+            # we haven't done anything, so this is "abort before we've
+            # connected"
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_leave_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("boom")
+            session.onLeave = async_exception_raiser(exception)
+            msg = message.Abort(u"testing")
+
+            # we haven't done anything, so this is "abort before we've
+            # connected"
+            session.onMessage(msg)
+
+            # make sure we got the right error out of onUserError
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_leave_valid_session(self):
+            '''
+            cover when onLeave called after we have a valid session
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onLeave = exception_raiser(exception)
+            # we have to get to an established connection first...
+            session.onMessage(create_mock_welcome())
+            self.assertTrue(session._session_id is not None)
+
+            # okay we have a session ("because ._session_id is not None")
+            msg = message.Goodbye()
+            session.onMessage(msg)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_leave_valid_session_deferred(self):
+            '''
+            cover when onLeave called after we have a valid session
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onLeave = async_exception_raiser(exception)
+            # we have to get to an established connection first...
+            session.onMessage(create_mock_welcome())
+            self.assertTrue(session._session_id is not None)
+
+            # okay we have a session ("because ._session_id is not None")
+            msg = message.Goodbye()
+            session.onMessage(msg)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_leave_after_bad_challenge(self):
+            '''
+            onLeave raises error after onChallenge fails
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onLeave = exception_raiser(exception)
+            session.onChallenge = exception_raiser(exception)
+            # make a challenge (which will fail, and then the
+            # subsequent onLeave will also fail)
+            msg = message.Challenge(u"foo")
+            session.onMessage(msg)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_disconnect_via_close(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("sideways")
+            session.onDisconnect = exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_disconnect_via_close_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("sideways")
+            session.onDisconnect = async_exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        # XXX FIXME Probably more ways to call onLeave!
+
+        def test_on_challenge(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onChallenge = exception_raiser(exception)
+            msg = message.Challenge(u"foo")
+
+            # execute
+            session.onMessage(msg)
+
+            # we already handle any onChallenge errors as "abort the
+            # connection". So make sure our error showed up in the
+            # fake-transport.
+            self.assertEqual(0, len(session.errors))
+            self.assertEqual(1, len(session._transport.messages))
+            reply = session._transport.messages[0]
+            self.assertIsInstance(reply, message.Abort)
+            self.assertEqual("such challenge", reply.message)
+
+        def test_on_challenge_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onChallenge = async_exception_raiser(exception)
+            msg = message.Challenge(u"foo")
+
+            # execute
+            session.onMessage(msg)
+
+            # we already handle any onChallenge errors as "abort the
+            # connection". So make sure our error showed up in the
+            # fake-transport.
+            self.assertEqual(0, len(session.errors))
+            self.assertEqual(1, len(session._transport.messages))
+            reply = session._transport.messages[0]
+            self.assertIsInstance(reply, message.Abort)
+            self.assertEqual("such challenge", reply.message)
+
+        def test_no_session(self):
+            '''
+            test "all other cases" when we don't yet have a session
+            established, which should all raise ProtocolErrors and
+            *not* go through the onUserError handler. We cheat and
+            just test one.
+            '''
+            session = MockApplicationSession()
+            exception = RuntimeError("such challenge")
+            session.onConnect = exception_raiser(exception)
+
+            for msg in [message.Goodbye()]:
+                self.assertRaises(ProtocolError, session.onMessage, (msg,))
+            self.assertEqual(0, len(session.errors))
+
+        def test_on_disconnect(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("oh sadness")
+            session.onDisconnect = exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_disconnect_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("oh sadness")
+            session.onDisconnect = async_exception_raiser(exception)
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_disconnect_with_session(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onDisconnect = exception_raiser(exception)
+            # create a valid session
+            session.onMessage(create_mock_welcome())
+
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(2, len(session.errors))
+            # might want to re-think this?
+            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][0]))
+            self.assertEqual(exception, session.errors[1][0])
+
+        def test_on_disconnect_with_session_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onDisconnect = async_exception_raiser(exception)
+            # create a valid session
+            session.onMessage(create_mock_welcome())
+
+            # we short-cut the whole state-machine traversal here by
+            # just calling onClose directly, which would normally be
+            # called via a Protocol, e.g.,
+            # autobahn.wamp.websocket.WampWebSocketProtocol
+            session.onClose(False)
+
+            self.assertEqual(2, len(session.errors))
+            # might want to re-think this?
+            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][0]))
+            self.assertEqual(exception, session.errors[1][0])
+
+        def test_on_connect(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onConnect = exception_raiser(exception)
+            trans = MockTransport()
+
+            # normally would be called from a Protocol?
+            session.onOpen(trans)
+
+            # shouldn't have done the .join()
+            self.assertEqual(0, len(trans.messages))
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        def test_on_connect_deferred(self):
+            session = MockApplicationSession()
+            exception = RuntimeError("the pain runs deep")
+            session.onConnect = async_exception_raiser(exception)
+            trans = MockTransport()
+
+            # normally would be called from a Protocol?
+            session.onOpen(trans)
+
+            # shouldn't have done the .join()
+            self.assertEqual(0, len(trans.messages))
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
+
+        # XXX likely missing other ways to invoke the above. need to
+        # cover, for sure:
+        #
+        # onChallenge
+        # onJoin
+        # onLeave
+        # onDisconnect
+        #
+        # what about other ISession ones?
+        # onConnect
+        # onDisconnect
+
+        # NOTE: for Event stuff, that is publish() handlers,
+        # test_publish_callback_exception in test_protocol.py already
+        # covers exceptions coming from user-code.

--- a/doc/work/programming.rst
+++ b/doc/work/programming.rst
@@ -330,7 +330,7 @@ Call a remote procedure which produces interim, progressive results:
       print("{} items deleted so far ..".format(n))
 
    total = yield session.call("com.myapp.log.delete",
-                              options = CallOptions(onProgress = deletedSoFar))
+                              options = CallOptions(on_progress = deletedSoFar))
    print("{} items deleted in total.".format(total))
 
 Distributed calls
@@ -524,7 +524,7 @@ and can be called like this
       print("{} items processed so far ..".format(i))
 
    total = yield session.call("com.myapp.longop", 10,
-                              options = CallOptions(onProgress = processedSoFar))
+                              options = CallOptions(on_progress = processedSoFar))
    print("{} items deleted in total.".format(total))
 
 Registration with invocation details

--- a/examples/asyncio/wamp/basic/rpc/progress/frontend.py
+++ b/examples/asyncio/wamp/basic/rpc/progress/frontend.py
@@ -46,7 +46,7 @@ class Component(ApplicationSession):
         def on_progress(i):
             print("Progress: {}".format(i))
 
-        res = yield from self.call('com.myapp.longop', 3, options=CallOptions(onProgress=on_progress))
+        res = yield from self.call('com.myapp.longop', 3, options=CallOptions(on_progress=on_progress))
 
         print("Final: {}".format(res))
 

--- a/examples/twisted/wamp/basic/rpc/progress/frontend.py
+++ b/examples/twisted/wamp/basic/rpc/progress/frontend.py
@@ -44,7 +44,7 @@ class Component(ApplicationSession):
         def on_progress(i):
             print("Progress: {}".format(i))
 
-        res = yield self.call('com.myapp.longop', 3, options=CallOptions(onProgress=on_progress))
+        res = yield self.call('com.myapp.longop', 3, options=CallOptions(on_progress=on_progress))
 
         print("Final: {}".format(res))
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist = flake8,
 deps =
     pytest
     mock
+    coverage
 commands = python -m pytest
 whitelist_externals = sh
 
@@ -63,9 +64,14 @@ setenv =
 commands =
    sh -c "which python"
    sh -c "which trial"
+   sh -c "which coverage"
    python -V
-   trial --version
-   trial autobahn
+   coverage --version
+   {envbindir}/trial --version
+   # XXX should probably add --branch
+   coverage run --source=autobahn --omit=*test* {envbindir}/trial autobahn
+   coverage report --show-missing
+   coverage html
 basepython = python2.7
 install_command = pip install {packages} autobahn[twisted,serialization]
 setenv =


### PR DESCRIPTION
This is a portion of #358 with just the sync and async error-handling and logging added (i.e. it doesn't change the ``onUserError`` or errback APIs).

Since there was a bug in onProgress versus on_progress, this in in here as well; I can take that out as well if you like (it's in a separate commit).

It does make a slight change to ``_add_future_callbacks()`` API so that you can pass ``None`` as a callback in order to provde a way to add *just* an errback.

Note that I re-based the unit-tests to (all) be in a separate commit from the code-changes. Is it better to have the unit-tests in the same commit as the code-changes?