### PR TITLE
Respect multiple decoration with @subscribe and @register. fixes #335

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -1062,11 +1062,11 @@ class ApplicationSession(BaseSession):
             for k in inspect.getmembers(handler.__class__, is_method_or_function):
                 proc = k[1]
                 if "_wampuris" in proc.__dict__:
-                    pat = proc.__dict__["_wampuris"][0]
-                    if pat.is_handler():
-                        uri = pat.uri()
-                        subopts = options or pat.subscribe_options()
-                        on_replies.append(_subscribe(handler, proc, uri, subopts))
+                    for pat in proc.__dict__["_wampuris"]:
+                        if pat.is_handler():
+                            uri = pat.uri()
+                            subopts = options or pat.subscribe_options()
+                            on_replies.append(_subscribe(handler, proc, uri, subopts))
 
             return self._gather_futures(on_replies, consume_exceptions=True)
 
@@ -1189,10 +1189,10 @@ class ApplicationSession(BaseSession):
             for k in inspect.getmembers(endpoint.__class__, is_method_or_function):
                 proc = k[1]
                 if "_wampuris" in proc.__dict__:
-                    pat = proc.__dict__["_wampuris"][0]
-                    if pat.is_endpoint():
-                        uri = pat.uri()
-                        on_replies.append(_register(endpoint, proc, uri, options))
+                    for pat in proc.__dict__["_wampuris"]:
+                        if pat.is_endpoint():
+                            uri = pat.uri()
+                            on_replies.append(_register(endpoint, proc, uri, options))
 
             return self._gather_futures(on_replies, consume_exceptions=True)
 


### PR DESCRIPTION
The motivation for subscribe is pretty simple. There are cases where published topics are handled by the same function.

For register it's a bit harder to find a use-case, but maybe this could be a good solution for some authorization problems. Or maybe services of multiple tiers with a unified client, where the simplest service just registers the same function for many URIs.