### PR TITLE
Fixes tavendo/AutobahnPython#373 unknown features ignored w/o an exception

### DIFF
--- a/autobahn/autobahn/wamp/role.py
+++ b/autobahn/autobahn/wamp/role.py
@@ -53,7 +53,8 @@ class RoleCommonPubSubFeatures(RoleFeatures):
 
    def __init__(self,
                 publisher_identification = None,
-                partitioned_pubsub = None):
+                partitioned_pubsub = None,
+                **kwargs):
 
       self.publisher_identification = publisher_identification
       self.partitioned_pubsub = partitioned_pubsub
@@ -128,7 +129,8 @@ class RoleCommonRpcFeatures(RoleFeatures):
                 partitioned_rpc = None,
                 call_timeout = None,
                 call_canceling = None,
-                progressive_call_results = None):
+                progressive_call_results = None,
+                **kwargs):
       self.caller_identification = caller_identification
       self.partitioned_rpc = partitioned_rpc
       self.call_timeout = call_timeout


### PR DESCRIPTION
Related to tavendo/AutobahnPython#373

This patch can be applied to the 0.9.3-3 tag (but github doesn't seem to let me create the pull request like that).

I presume 0.9.x is deprecated and not being maintained, but thought I would submit this bug fix for those who aren't switching to 0.10.x.