### PR TITLE
Check for transport in onLeave

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -961,7 +961,9 @@ class ApplicationSession(BaseSession):
         """
         Implements :func:`autobahn.wamp.interfaces.ISession.onLeave`
         """
-        self.disconnect()
+        if self._transport:
+            self.disconnect()
+        # do we ever call onLeave with a valid transport?
 
     def leave(self, reason=None, log_message=None):
         """

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -154,6 +154,15 @@ if os.environ.get('USE_TWISTED', False):
         def abort(self):
             pass
 
+    class TestClose(unittest.TestCase):
+        def test_server_abort(self):
+            handler = ApplicationSession()
+            MockTransport(handler)
+
+            # this should not raise an exception, but did when this
+            # test-case was written
+            handler.onClose(False)
+
     class TestPublisher(unittest.TestCase):
 
         @inlineCallbacks

--- a/autobahn/wamp/test/test_user_handler_errors.py
+++ b/autobahn/wamp/test/test_user_handler_errors.py
@@ -333,10 +333,8 @@ if os.environ.get('USE_TWISTED', False):
             # autobahn.wamp.websocket.WampWebSocketProtocol
             session.onClose(False)
 
-            self.assertEqual(2, len(session.errors))
-            # might want to re-think this?
-            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][0]))
-            self.assertEqual(exception, session.errors[1][0])
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
 
         def test_on_disconnect_with_session_deferred(self):
             session = MockApplicationSession()
@@ -351,10 +349,8 @@ if os.environ.get('USE_TWISTED', False):
             # autobahn.wamp.websocket.WampWebSocketProtocol
             session.onClose(False)
 
-            self.assertEqual(2, len(session.errors))
-            # might want to re-think this?
-            self.assertEqual("No transport, but disconnect() called.", str(session.errors[0][0]))
-            self.assertEqual(exception, session.errors[1][0])
+            self.assertEqual(1, len(session.errors))
+            self.assertEqual(exception, session.errors[0][0])
 
         def test_on_connect(self):
             session = MockApplicationSession()


### PR DESCRIPTION
If our connection was lost we call onClose, which always calls
onLeave, which always does disconnect() -- however if we've
already lost our connection, we don't need to disconnect.

This results in spurious errors during SIGINT shutdown; see crossbar/#278

Two user-error handling test-cases were already "expecting" this
error, so those are changed too...