### PR TITLE
Remove use of * in imports so pyflakes can check the code for undefined names

### DIFF
--- a/autobahn/websocket/compress.py
+++ b/autobahn/websocket/compress.py
@@ -26,8 +26,20 @@
 
 from __future__ import absolute_import
 
-from autobahn.websocket.compress_base import *  # noqa
-from autobahn.websocket.compress_deflate import *  # noqa
+from autobahn.websocket.compress_base import \
+    PerMessageCompressOffer, \
+    PerMessageCompressOfferAccept, \
+    PerMessageCompressResponse, \
+    PerMessageCompressResponseAccept, \
+    PerMessageCompress
+
+from autobahn.websocket.compress_deflate import \
+    PerMessageDeflateMixin, \
+    PerMessageDeflateOffer, \
+    PerMessageDeflateOfferAccept, \
+    PerMessageDeflateResponse, \
+    PerMessageDeflateResponseAccept, \
+    PerMessageDeflate
 
 # this must be a list (not tuple), since we dynamically
 # extend it ..
@@ -65,7 +77,13 @@ try:
 except ImportError:
     bz2 = None
 else:
-    from autobahn.websocket.compress_bzip2 import *  # noqa
+    from autobahn.websocket.compress_bzip2 import \
+        PerMessageBzip2Mixin, \
+        PerMessageBzip2Offer, \
+        PerMessageBzip2OfferAccept, \
+        PerMessageBzip2Response, \
+        PerMessageBzip2ResponseAccept, \
+        PerMessageBzip2
 
     PMCE = {
         'Offer': PerMessageBzip2Offer,
@@ -91,7 +109,13 @@ try:
 except ImportError:
     snappy = None
 else:
-    from autobahn.websocket.compress_snappy import *  # noqa
+    from autobahn.websocket.compress_snappy import \
+        PerMessageSnappyMixin, \
+        PerMessageSnappyOffer, \
+        PerMessageSnappyOfferAccept, \
+        PerMessageSnappyResponse, \
+        PerMessageSnappyResponseAccept, \
+        PerMessageSnappy
 
     PMCE = {
         'Offer': PerMessageSnappyOffer,

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -49,7 +49,7 @@ from autobahn.websocket.interfaces import IWebSocketChannel, \
 from autobahn.util import Stopwatch, newid, wildcards2patterns
 from autobahn.websocket.utf8validator import Utf8Validator
 from autobahn.websocket.xormasker import XorMaskerNull, createXorMasker
-from autobahn.websocket.compress import *  # noqa
+from autobahn.websocket.compress import PERMESSAGE_COMPRESSION_EXTENSION
 from autobahn.websocket import http
 
 from six.moves import urllib
@@ -790,7 +790,7 @@ class WebSocketProtocol(object):
 
         :param code: Close status code, if there was one (:class:`WebSocketProtocol`.CLOSE_STATUS_CODE_*).
         :type code: int or None
-        :param reason: Close reason (when present, a status code MUST have been also be present).
+        :param reasonRaw: Close reason (when present, a status code MUST have been also be present).
         :type reason: str or None
         """
         if self.debugCodePaths:
@@ -856,7 +856,7 @@ class WebSocketProtocol(object):
             else:
                 # Either reply with same code/reason, or code == NORMAL/reason=None
                 if self.echoCloseCodeReason:
-                    self.sendCloseFrame(code=code, reasonUtf8=reason.encode("UTF-8"), isReply=True)
+                    self.sendCloseFrame(code=code, reasonUtf8=reasonRaw.encode("UTF-8"), isReply=True)
                 else:
                     self.sendCloseFrame(code=WebSocketProtocol.CLOSE_STATUS_CODE_NORMAL, isReply=True)
 


### PR DESCRIPTION
I just ran across the `taxio` typo in `autobahn/websocket/protocol.py`, that turned out to be fixed in master but not in the code I had.  That sort of error should be caught by pyflakes or similar tool.  In this pr I have changed the use of `*` in imports so that pyflakes can run properly.

As a result one other undefined variable was also spotted (`reason` in place of `reasonRaw`).  don't think the fixed code is right though, since `reasonRaw` could be `None`.

It would be good if the `Makefile` could run a Python 2 pyflakes on the python2 code, and a Python 3 one on the python3 code, etc.   There are some imported things that aren't used, but I haven't cleaned them up for now as I'm not sure if some of them are important, e.g., the import of `reactor` in `autobahn/wamp/test/test_runner.py`.