### PR TITLE
Filter out None entries from PublishOptions exclude list

### DIFF
--- a/autobahn/wamp/types.py
+++ b/autobahn/wamp/types.py
@@ -330,6 +330,9 @@ class PublishOptions(object):
            to subscribers.
         :type disclose_me: bool
         """
+        # filter out None entries from exclude list, so it's easier for callers
+        if type(exclude) == list:
+            exclude = [x for x in exclude if x is not None]
         assert(acknowledge is None or type(acknowledge) == bool)
         assert(exclude_me is None or type(exclude_me) == bool)
         assert(exclude is None or (type(exclude) == list and all(type(x) in six.integer_types for x in exclude)))


### PR DESCRIPTION
This makes it easier for callers so that they don't have
to check if, e.g., details.caller is None before passing it
to PublishOptions(exclude=[...])