### PR TITLE
Added ssl argument to asyncio.wamp.ApplicationRunner to allow passing an SSL context for client connections

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -32,11 +32,11 @@ from autobahn.websocket.protocol import parseWsUrl
 from autobahn.asyncio.websocket import WampWebSocketClientFactory
 
 try:
-    from asyncio import get_event_loop
+    import asyncio
 except ImportError:
-    # Trollius >= 0.3 was renamed
+    # Trollius >= 0.3 was renamed to asyncio
     # noinspection PyUnresolvedReferences
-    from trollius import get_event_loop
+    import trollius as asyncio
 
 import txaio
 txaio.use_asyncio()
@@ -75,7 +75,8 @@ class ApplicationRunner(object):
     """
 
     def __init__(self, url, realm, extra=None, serializers=None,
-                 debug=False, debug_wamp=False, debug_app=False):
+                 debug=False, debug_wamp=False, debug_app=False,
+                 ssl=None):
         """
 
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
@@ -93,6 +94,9 @@ class ApplicationRunner(object):
         :type debug_wamp: bool
         :param debug_app: Turn on app-level debugging.
         :type debug_app: bool
+        :param ssl: An (optional) SSL context instance or a bool. See the documentation for the
+           `loop.create_connection` asyncio method, to which this value is passed.
+        :type ssl: :class`ssl.SSLContext`
         """
         self.url = url
         self.realm = realm
@@ -102,6 +106,7 @@ class ApplicationRunner(object):
         self.debug_app = debug_app
         self.make = None
         self.serializers = serializers
+        self.ssl = ssl
 
     def run(self, make):
         """
@@ -119,22 +124,32 @@ class ApplicationRunner(object):
             except Exception as e:
                 # the app component could not be created .. fatal
                 print(e)
-                get_event_loop().stop()
+                asyncio.get_event_loop().stop()
             else:
                 session.debug_app = self.debug_app
                 return session
 
         isSecure, host, port, resource, path, params = parseWsUrl(self.url)
 
+        if self.ssl is None:
+            ssl = isSecure
+        else:
+            if self.ssl and not isSecure:
+                raise Exception(
+                    'ssl argument value passed to %s conflicts with the "ws:" '
+                    'prefix of the url argument. Did you mean to use "wss:"?' %
+                    self.__class__.__name__)
+            ssl = self.ssl
+
         # 2) create a WAMP-over-WebSocket transport client factory
         transport_factory = WampWebSocketClientFactory(create, url=self.url, serializers=self.serializers,
                                                        debug=self.debug, debug_wamp=self.debug_wamp)
 
         # 3) start the client
-        loop = get_event_loop()
+        loop = asyncio.get_event_loop()
         txaio.use_asyncio()
         txaio.config.loop = loop
-        coro = loop.create_connection(transport_factory, host, port, ssl=isSecure)
+        coro = loop.create_connection(transport_factory, host, port, ssl=ssl)
         loop.run_until_complete(coro)
 
         # 4) now enter the asyncio event loop

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -54,7 +54,7 @@ try:
 except ImportError:
     # Not on PY3 yet
     service = None
-    __all__.pop(__all__.index("Service"))
+    __all__ = tuple(list(__all__).pop(__all__.index('Service')))
 
 
 class ApplicationSession(protocol.ApplicationSession):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -41,20 +41,20 @@ import txaio
 txaio.use_twisted()
 
 
-__all__ = (
+__all__ = [
     'ApplicationSession',
     'ApplicationSessionFactory',
     'ApplicationRunner',
     'Application',
     'Service'
-)
+]
 
 try:
     from twisted.application import service
 except ImportError:
     # Not on PY3 yet
     service = None
-    __all__ = tuple(list(__all__).pop(__all__.index('Service')))
+    __all__.pop(__all__.index('Service'))
 
 
 class ApplicationSession(protocol.ApplicationSession):

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -89,11 +89,12 @@ else:
     # Asyncio tests.
     try:
         import asyncio
+        from unittest.mock import patch, Mock
     except ImportError:
         # Trollius >= 0.3 was renamed to asyncio
         # noinspection PyUnresolvedReferences
         import trollius as asyncio
-    from unittest.mock import patch, Mock
+        from mock import patch, Mock
     from autobahn.asyncio.wamp import ApplicationRunner
 
 

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -97,11 +97,19 @@ else:
         from mock import patch, Mock
     from autobahn.asyncio.wamp import ApplicationRunner
 
-
     class TestApplicationRunner(unittest.TestCase):
         '''
         Test the autobahn.asyncio.wamp.ApplicationRunner class.
         '''
+        def _assertRaisesRegex(self, exception, error, *args, **kw):
+            try:
+                self.assertRaisesRegex
+            except AttributeError:
+                f = self.assertRaisesRegexp
+            else:
+                f = self.assertRaisesRegex
+            f(exception, error, *args, **kw)
+
         def test_explicit_SSLContext(self):
             '''
             Ensure that loop.create_connection is called with the exact SSL
@@ -156,20 +164,19 @@ else:
                 error = ('^ssl argument value passed to ApplicationRunner '
                          'conflicts with the "ws:" prefix of the url '
                          'argument\. Did you mean to use "wss:"\?$')
-                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+                self._assertRaisesRegex(Exception, error, runner.run, '_unused_')
 
         def test_conflict_SSLContext_with_ws_url(self):
             '''
             ApplicationRunner must raise an exception if given an ssl value that is
             an instance of SSLContext, but only a "ws:" URL.
             '''
-            import ssl
             loop = Mock()
             loop.create_connection = Mock()
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
-                                           ssl=ssl.create_default_context())
+                                           ssl='_unused_')
                 error = ('^ssl argument value passed to ApplicationRunner '
                          'conflicts with the "ws:" prefix of the url '
                          'argument\. Did you mean to use "wss:"\?$')
-                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+                self._assertRaisesRegex(Exception, error, runner.run, '_unused_')

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -31,9 +31,9 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from mock import patch
 
 if os.environ.get('USE_TWISTED', False):
+    from mock import patch
     from zope.interface import implementer
     from twisted.internet.interfaces import IReactorTime
 
@@ -85,3 +85,90 @@ if os.environ.get('USE_TWISTED', False):
                     runner.run, lambda _: None, start_reactor=True
                 )
                 self.assertTrue(mockreactor.stop_called)
+else:
+    # Asyncio tests.
+    try:
+        import asyncio
+    except ImportError:
+        # Trollius >= 0.3 was renamed to asyncio
+        # noinspection PyUnresolvedReferences
+        import trollius as asyncio
+    from unittest.mock import patch, Mock
+    from autobahn.asyncio.wamp import ApplicationRunner
+
+
+    class TestApplicationRunner(unittest.TestCase):
+        '''
+        Test the autobahn.asyncio.wamp.ApplicationRunner class.
+        '''
+        def test_explicit_SSLContext(self):
+            '''
+            Ensure that loop.create_connection is called with the exact SSL
+            context object that is passed (as ssl) to the __init__ method of
+            ApplicationRunner.
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                ssl = {}
+                runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm',
+                                           ssl=ssl)
+                runner.run('_unused_')
+                self.assertIs(ssl, loop.create_connection.call_args[1]['ssl'])
+
+        def test_omitted_SSLContext_insecure(self):
+            '''
+            Ensure that loop.create_connection is called with ssl=False
+            if no ssl argument is passed to the __init__ method of
+            ApplicationRunner and the websocket URL starts with "ws:".
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm')
+                runner.run('_unused_')
+                self.assertIs(False, loop.create_connection.call_args[1]['ssl'])
+
+        def test_omitted_SSLContext_secure(self):
+            '''
+            Ensure that loop.create_connection is called with ssl=True
+            if no ssl argument is passed to the __init__ method of
+            ApplicationRunner and the websocket URL starts with "wss:".
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('wss://127.0.0.1:8080/wss', 'realm')
+                runner.run('_unused_')
+                self.assertIs(True, loop.create_connection.call_args[1]['ssl'])
+
+        def test_conflict_SSL_True_with_ws_url(self):
+            '''
+            ApplicationRunner must raise an exception if given an ssl value of True
+            but only a "ws:" URL.
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
+                                           ssl=True)
+                error = ('^ssl argument value passed to ApplicationRunner '
+                         'conflicts with the "ws:" prefix of the url '
+                         'argument\. Did you mean to use "wss:"\?$')
+                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+
+        def test_conflict_SSLContext_with_ws_url(self):
+            '''
+            ApplicationRunner must raise an exception if given an ssl value that is
+            an instance of SSLContext, but only a "ws:" URL.
+            '''
+            import ssl
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
+                                           ssl=ssl.create_default_context())
+                error = ('^ssl argument value passed to ApplicationRunner '
+                         'conflicts with the "ws:" prefix of the url '
+                         'argument\. Did you mean to use "wss:"\?$')
+                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')


### PR DESCRIPTION
Added tests for this.

Also (sorry...) fixed an unrelated trivial error (in `autobahn/twisted/wamp.py`) in which `pop` was being called on a `tuple`. This was causing the following failure with `make test_asyncio`:

```
autobahn/wamp/test/test_component.py:37: in <module>
    from autobahn.twisted import wamp
autobahn/twisted/wamp.py:57: in <module>
    __all__.pop(__all__.index("Service"))
E   AttributeError: 'tuple' object has no attribute 'pop'
```