### PR TITLE
Issue388 ensure text keys

### DIFF
--- a/autobahn/wamp/serializer.py
+++ b/autobahn/wamp/serializer.py
@@ -303,7 +303,7 @@ else:
                 """
                 for (k, v) in six.iteritems(d):
                     if not isinstance(k, six.text_type):
-                        newk = six.text_type(k)
+                        newk = six.text_type(k, encoding='utf8')
                         del d[k]
                         d[newk] = v
                 return d


### PR DESCRIPTION
Multiple issues with the previous solution:

 - unit-tests (*and* my end-to-end test, unfortunately) only checked the TYPE of keys, not content
 - encoding='utf8' is required for python3.3+
 - ...otherwise you get keys like `b'str'` (with the b quote content quote embedded in the string)

Now, the tests are more-correct, along with the encoding.