### PR TITLE
Pass TLS context

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -32,11 +32,11 @@ from autobahn.websocket.protocol import parseWsUrl
 from autobahn.asyncio.websocket import WampWebSocketClientFactory
 
 try:
-    from asyncio import get_event_loop
+    import asyncio
 except ImportError:
-    # Trollius >= 0.3 was renamed
+    # Trollius >= 0.3 was renamed to asyncio
     # noinspection PyUnresolvedReferences
-    from trollius import get_event_loop
+    import trollius as asyncio
 
 import txaio
 txaio.use_asyncio()
@@ -75,7 +75,8 @@ class ApplicationRunner(object):
     """
 
     def __init__(self, url, realm, extra=None, serializers=None,
-                 debug=False, debug_wamp=False, debug_app=False):
+                 debug=False, debug_wamp=False, debug_app=False,
+                 ssl=None):
         """
 
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
@@ -93,6 +94,9 @@ class ApplicationRunner(object):
         :type debug_wamp: bool
         :param debug_app: Turn on app-level debugging.
         :type debug_app: bool
+        :param ssl: An (optional) SSL context instance or a bool. See the documentation for the
+           `loop.create_connection` asyncio method, to which this value is passed.
+        :type ssl: :class`ssl.SSLContext`
         """
         self.url = url
         self.realm = realm
@@ -102,6 +106,7 @@ class ApplicationRunner(object):
         self.debug_app = debug_app
         self.make = None
         self.serializers = serializers
+        self.ssl = ssl
 
     def run(self, make):
         """
@@ -119,22 +124,32 @@ class ApplicationRunner(object):
             except Exception as e:
                 # the app component could not be created .. fatal
                 print(e)
-                get_event_loop().stop()
+                asyncio.get_event_loop().stop()
             else:
                 session.debug_app = self.debug_app
                 return session
 
         isSecure, host, port, resource, path, params = parseWsUrl(self.url)
 
+        if self.ssl is None:
+            ssl = isSecure
+        else:
+            if self.ssl and not isSecure:
+                raise Exception(
+                    'ssl argument value passed to %s conflicts with the "ws:" '
+                    'prefix of the url argument. Did you mean to use "wss:"?' %
+                    self.__class__.__name__)
+            ssl = self.ssl
+
         # 2) create a WAMP-over-WebSocket transport client factory
         transport_factory = WampWebSocketClientFactory(create, url=self.url, serializers=self.serializers,
                                                        debug=self.debug, debug_wamp=self.debug_wamp)
 
         # 3) start the client
-        loop = get_event_loop()
+        loop = asyncio.get_event_loop()
         txaio.use_asyncio()
         txaio.config.loop = loop
-        coro = loop.create_connection(transport_factory, host, port, ssl=isSecure)
+        coro = loop.create_connection(transport_factory, host, port, ssl=ssl)
         loop.run_until_complete(coro)
 
         # 4) now enter the asyncio event loop

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -143,7 +143,7 @@ class ApplicationRunner(object):
             ssl = isSecure
         else:
             if self.ssl and not isSecure:
-                raise Exception(
+                raise RuntimeError(
                     'ssl argument value passed to %s conflicts with the "ws:" '
                     'prefix of the url argument. Did you mean to use "wss:"?' %
                     self.__class__.__name__)

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -78,25 +78,33 @@ class ApplicationRunner(object):
                  debug=False, debug_wamp=False, debug_app=False,
                  ssl=None):
         """
-
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
         :type url: unicode
+
         :param realm: The WAMP realm to join the application session to.
         :type realm: unicode
+
         :param extra: Optional extra configuration to forward to the application component.
         :type extra: dict
+
         :param serializers: A list of WAMP serializers to use (or None for default serializers).
            Serializers must implement :class:`autobahn.wamp.interfaces.ISerializer`.
         :type serializers: list
+
         :param debug: Turn on low-level debugging.
         :type debug: bool
+
         :param debug_wamp: Turn on WAMP-level debugging.
         :type debug_wamp: bool
+
         :param debug_app: Turn on app-level debugging.
         :type debug_app: bool
-        :param ssl: An (optional) SSL context instance or a bool. See the documentation for the
-           `loop.create_connection` asyncio method, to which this value is passed.
-        :type ssl: :class`ssl.SSLContext`
+
+        :param ssl: An (optional) SSL context instance or a bool. See
+           the documentation for the `loop.create_connection` asyncio
+           method, to which this value is passed as the ``ssl=``
+           kwarg.
+        :type ssl: :class:`ssl.SSLContext` or bool
         """
         self.url = url
         self.realm = realm

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -54,7 +54,7 @@ try:
 except (ImportError, SyntaxError):
     # Not on PY3 yet
     service = None
-    __all__.pop(__all__.index("Service"))
+    __all__ = tuple(list(__all__).pop(__all__.index('Service')))
 
 
 class ApplicationSession(protocol.ApplicationSession):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -54,7 +54,7 @@ try:
 except (ImportError, SyntaxError):
     # Not on PY3 yet
     service = None
-    __all__ = tuple(list(__all__).pop(__all__.index('Service')))
+    __all__.pop(__all__.index('Service'))
 
 
 class ApplicationSession(protocol.ApplicationSession):

--- a/autobahn/twisted/wamp.py
+++ b/autobahn/twisted/wamp.py
@@ -93,21 +93,34 @@ class ApplicationRunner(object):
     connecting to a WAMP router.
     """
 
-    def __init__(self, url, realm, extra=None, debug=False, debug_wamp=False, debug_app=False):
+    def __init__(self, url, realm, extra=None, debug=False, debug_wamp=False, debug_app=False, ssl=None):
         """
-
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
         :type url: unicode
+
         :param realm: The WAMP realm to join the application session to.
         :type realm: unicode
+
         :param extra: Optional extra configuration to forward to the application component.
         :type extra: dict
+
         :param debug: Turn on low-level debugging.
         :type debug: bool
+
         :param debug_wamp: Turn on WAMP-level debugging.
         :type debug_wamp: bool
+
         :param debug_app: Turn on app-level debugging.
         :type debug_app: bool
+
+        :param ssl: (Optional). If specified this should be an
+            instance suitable to pass as ``sslContextFactory`` to
+            :class:`twisted.internet.endpoints.SSL4ClientEndpoint`` such
+            as :class:`twisted.internet.ssl.CertificateOptions`. Leaving
+            it as ``None`` will use the result of calling Twisted's
+            :meth:`twisted.internet.ssl.platformTrust` which tries to use
+            your distribution's CA certificates.
+        :type ssl: :class:`twisted.internet.ssl.CertificateOptions`
         """
         self.url = url
         self.realm = realm
@@ -116,6 +129,7 @@ class ApplicationRunner(object):
         self.debug_wamp = debug_wamp
         self.debug_app = debug_app
         self.make = None
+        self.ssl = ssl
 
     def run(self, make, start_reactor=True):
         """
@@ -169,15 +183,28 @@ class ApplicationRunner(object):
         transport_factory = WampWebSocketClientFactory(create, url=self.url,
                                                        debug=self.debug, debug_wamp=self.debug_wamp)
 
-        # start the client from a Twisted endpoint
-        from twisted.internet.endpoints import clientFromString
+        # if user passed ssl= but isn't using isSecure, we'll never
+        # use the ssl argument which makes no sense.
+        context_factory = None
+        if self.ssl is not None:
+            if not isSecure:
+                raise RuntimeError(
+                    'ssl= argument value passed to %s conflicts with the "ws:" '
+                    'prefix of the url argument. Did you mean to use "wss:"?' %
+                    self.__class__.__name__)
+            context_factory = self.ssl
+        elif isSecure:
+            from twisted.internet.ssl import platformTrust
+            context_factory = platformTrust()
 
         if isSecure:
-            endpoint_descriptor = "ssl:{0}:{1}".format(host, port)
+            from twisted.internet.endpoints import SSL4ClientEndpoint
+            assert context_factory is not None
+            client = SSL4ClientEndpoint(reactor, host, port, context_factory)
         else:
-            endpoint_descriptor = "tcp:{0}:{1}".format(host, port)
+            from twisted.internet.endpoints import TCP4ClientEndpoint
+            client = TCP4ClientEndpoint(reactor, host, port)
 
-        client = clientFromString(reactor, endpoint_descriptor)
         d = client.connect(transport_factory)
 
         # if the user didn't ask us to start the reactor, then they

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -89,11 +89,12 @@ else:
     # Asyncio tests.
     try:
         import asyncio
+        from unittest.mock import patch, Mock
     except ImportError:
         # Trollius >= 0.3 was renamed to asyncio
         # noinspection PyUnresolvedReferences
         import trollius as asyncio
-    from unittest.mock import patch, Mock
+        from mock import patch, Mock
     from autobahn.asyncio.wamp import ApplicationRunner
 
 

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -97,11 +97,19 @@ else:
         from mock import patch, Mock
     from autobahn.asyncio.wamp import ApplicationRunner
 
-
     class TestApplicationRunner(unittest.TestCase):
         '''
         Test the autobahn.asyncio.wamp.ApplicationRunner class.
         '''
+        def _assertRaisesRegex(self, exception, error, *args, **kw):
+            try:
+                self.assertRaisesRegex
+            except AttributeError:
+                f = self.assertRaisesRegexp
+            else:
+                f = self.assertRaisesRegex
+            f(exception, error, *args, **kw)
+
         def test_explicit_SSLContext(self):
             '''
             Ensure that loop.create_connection is called with the exact SSL
@@ -156,20 +164,19 @@ else:
                 error = ('^ssl argument value passed to ApplicationRunner '
                          'conflicts with the "ws:" prefix of the url '
                          'argument\. Did you mean to use "wss:"\?$')
-                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+                self._assertRaisesRegex(Exception, error, runner.run, '_unused_')
 
         def test_conflict_SSLContext_with_ws_url(self):
             '''
             ApplicationRunner must raise an exception if given an ssl value that is
             an instance of SSLContext, but only a "ws:" URL.
             '''
-            import ssl
             loop = Mock()
             loop.create_connection = Mock()
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
-                                           ssl=ssl.create_default_context())
+                                           ssl='_unused_')
                 error = ('^ssl argument value passed to ApplicationRunner '
                          'conflicts with the "ws:" prefix of the url '
                          'argument\. Did you mean to use "wss:"\?$')
-                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+                self._assertRaisesRegex(Exception, error, runner.run, '_unused_')

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -31,9 +31,9 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from mock import patch
 
 if os.environ.get('USE_TWISTED', False):
+    from mock import patch
     from zope.interface import implementer
     from twisted.internet.interfaces import IReactorTime
 
@@ -85,3 +85,90 @@ if os.environ.get('USE_TWISTED', False):
                     runner.run, lambda _: None, start_reactor=True
                 )
                 self.assertTrue(mockreactor.stop_called)
+else:
+    # Asyncio tests.
+    try:
+        import asyncio
+    except ImportError:
+        # Trollius >= 0.3 was renamed to asyncio
+        # noinspection PyUnresolvedReferences
+        import trollius as asyncio
+    from unittest.mock import patch, Mock
+    from autobahn.asyncio.wamp import ApplicationRunner
+
+
+    class TestApplicationRunner(unittest.TestCase):
+        '''
+        Test the autobahn.asyncio.wamp.ApplicationRunner class.
+        '''
+        def test_explicit_SSLContext(self):
+            '''
+            Ensure that loop.create_connection is called with the exact SSL
+            context object that is passed (as ssl) to the __init__ method of
+            ApplicationRunner.
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                ssl = {}
+                runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm',
+                                           ssl=ssl)
+                runner.run('_unused_')
+                self.assertIs(ssl, loop.create_connection.call_args[1]['ssl'])
+
+        def test_omitted_SSLContext_insecure(self):
+            '''
+            Ensure that loop.create_connection is called with ssl=False
+            if no ssl argument is passed to the __init__ method of
+            ApplicationRunner and the websocket URL starts with "ws:".
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm')
+                runner.run('_unused_')
+                self.assertIs(False, loop.create_connection.call_args[1]['ssl'])
+
+        def test_omitted_SSLContext_secure(self):
+            '''
+            Ensure that loop.create_connection is called with ssl=True
+            if no ssl argument is passed to the __init__ method of
+            ApplicationRunner and the websocket URL starts with "wss:".
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('wss://127.0.0.1:8080/wss', 'realm')
+                runner.run('_unused_')
+                self.assertIs(True, loop.create_connection.call_args[1]['ssl'])
+
+        def test_conflict_SSL_True_with_ws_url(self):
+            '''
+            ApplicationRunner must raise an exception if given an ssl value of True
+            but only a "ws:" URL.
+            '''
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
+                                           ssl=True)
+                error = ('^ssl argument value passed to ApplicationRunner '
+                         'conflicts with the "ws:" prefix of the url '
+                         'argument\. Did you mean to use "wss:"\?$')
+                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')
+
+        def test_conflict_SSLContext_with_ws_url(self):
+            '''
+            ApplicationRunner must raise an exception if given an ssl value that is
+            an instance of SSLContext, but only a "ws:" URL.
+            '''
+            import ssl
+            loop = Mock()
+            loop.create_connection = Mock()
+            with patch.object(asyncio, 'get_event_loop', return_value=loop):
+                runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
+                                           ssl=ssl.create_default_context())
+                error = ('^ssl argument value passed to ApplicationRunner '
+                         'conflicts with the "ws:" prefix of the url '
+                         'argument\. Did you mean to use "wss:"\?$')
+                self.assertRaisesRegex(Exception, error, runner.run, '_unused_')

--- a/examples/asyncio/wamp/basic/pubsub/tls/README
+++ b/examples/asyncio/wamp/basic/pubsub/tls/README
@@ -1,0 +1,3 @@
+This corresponds to the Twisted version with similar path; see the
+README there for how to configure crossbar and create a self-signed
+certificate.

--- a/examples/asyncio/wamp/basic/pubsub/tls/backend_selfsigned.py
+++ b/examples/asyncio/wamp/basic/pubsub/tls/backend_selfsigned.py
@@ -1,0 +1,66 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import print_function
+
+try:
+    import asyncio
+except ImportError:
+    # Trollius >= 0.3 was renamed
+    import trollius as asyncio
+
+from os import environ
+from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
+import ssl
+
+
+class Component(ApplicationSession):
+    """
+    An application component that publishes an event every second.
+    """
+
+    @asyncio.coroutine
+    def onJoin(self, details):
+        counter = 0
+        while True:
+            print("publish: com.myapp.topic1", counter)
+            self.publish('com.myapp.topic1', counter)
+            counter += 1
+            yield from asyncio.sleep(1)
+
+
+if __name__ == '__main__':
+    # create an ssl.Context using just our self-signed cert as the CA certificates
+    options = ssl.create_default_context(cadata=open('./server.crt', 'r').read())
+    # ...which we pass as "ssl=" to ApplicationRunner (passed to loop.create_connection)
+    runner = ApplicationRunner(
+        environ.get("AUTOBAHN_DEMO_ROUTER", "wss://demo.crossbar.io/ws"),
+        u"crossbardemo",
+        ssl=options,  # try removing this, but still use self-signed cert
+        debug_wamp=False,  # optional; log many WAMP details
+        debug=False,  # optional; log even more details
+    )
+    runner.run(Component)

--- a/examples/twisted/wamp/basic/pubsub/tls/README.md
+++ b/examples/twisted/wamp/basic/pubsub/tls/README.md
@@ -1,0 +1,27 @@
+# TLS
+
+This demonstrates how to use a custom `sslContextFactory` for
+SSL4ClientEndpoints to control how TLS verification is
+done. Specifically, we connect via wss:// to a TLS-enabled backend
+with a self-signed certificate.
+
+Use the script "create-self-signed-cert.sh" to create a new
+certificate in `server.crt` (with corresponding private key
+`server.key`). You can teach crossbar about your certificate by adding
+a "transport" configuration like the following::
+
+    {
+        "type": "websocket",
+        "id": "tls_test0",
+        "endpoint": {
+            "type": "tcp",
+            "port": 6464,
+            "tls": {
+                "key": "./server.key",
+                "certificate": "./server.crt"
+            }
+        }
+    }
+
+`backend_selfsigned.py` is designed to connect to a transport
+configured as above, and also needs access to the `server.crt` file.

--- a/examples/twisted/wamp/basic/pubsub/tls/backend_selfsigned.py
+++ b/examples/twisted/wamp/basic/pubsub/tls/backend_selfsigned.py
@@ -1,0 +1,72 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import print_function
+
+from os import environ
+from autobahn.twisted.util import sleep
+from autobahn.twisted.wamp import ApplicationSession, ApplicationRunner
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet._sslverify import OpenSSLCertificateAuthorities
+from twisted.internet.ssl import CertificateOptions
+from OpenSSL import crypto
+
+
+class Component(ApplicationSession):
+    """
+    An application component that publishes an event every second.
+    """
+
+    @inlineCallbacks
+    def onJoin(self, details):
+        counter = 0
+        while True:
+            print("publish: com.myapp.topic1", counter)
+            yield self.publish('com.myapp.topic1', counter)
+            counter += 1
+            yield sleep(1)
+
+
+if __name__ == '__main__':
+    # load the self-signed cert the server is using
+    cert = crypto.load_certificate(
+        crypto.FILETYPE_PEM,
+        unicode(open('./server.crt', 'r').read())
+    )
+    # tell Twisted to use just the one certificate we loaded to verify connections
+    options = CertificateOptions(
+        trustRoot=OpenSSLCertificateAuthorities([cert]),
+    )
+    # ...which we pass as "ssl=" to ApplicationRunner (passed to SSL4ClientEndpoint)
+    runner = ApplicationRunner(
+        environ.get("AUTOBAHN_DEMO_ROUTER", "wss://demo.crossbar.io/ws"),
+        u"crossbardemo",
+        ssl=options,  # try removing this, but still use self-signed cert
+        debug_wamp=False,  # optional; log many WAMP details
+        debug=False,  # optional; log even more details
+    )
+    runner.run(Component)

--- a/examples/twisted/wamp/basic/pubsub/tls/create-self-signed-cert.sh
+++ b/examples/twisted/wamp/basic/pubsub/tls/create-self-signed-cert.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+openssl req -nodes -new -x509 -keyout server.key \
+        -subj '/C=DE/ST=Bavaria/L=Erlangen/O=Tavendo/CN=localhost/' \
+        -out server.crt


### PR DESCRIPTION
This builds on @terrycojones PR #394 for adding an ``ssl=`` keyword argument to ``ApplicationRunner`` by adding a similar corresponding Twisted API, and examples using a self-signed certificate for both asyncio and Twisted.

Essentially we just export the underlying asyncio or Twisted APIs so autobahn's API becomes no more unstable that either of those.

Python's documentation recommends using ``ssl.create_default_context`` and only exposes an API that allows you to set ``ssl=`` kwarg (which is precisely what the asyncio version of this is doing).

Twisted's documentation recommends using a ``CertificateOptions``instance  as the ``sslContextFactory=`` kwarg to ``SSL4ClientEndpoint`` which is just what this code does.

Note if we merge/take this PR, #394 should be closed and remain unmerged (all terry's changes are in here, with correct author information). Or vice versa.