### PR TITLE
Shutdown with Goodbye

### DIFF
--- a/autobahn/twisted/test/test_application_runner.py
+++ b/autobahn/twisted/test/test_application_runner.py
@@ -88,9 +88,9 @@ if os.environ.get('USE_TWISTED', False):
 
             # shouldn't have actually connected to anything
             # successfully, and the run() call shouldn't have inserted
-            # any of its own call/errbacks.
+            # any of its own call/errbacks. (except the cleanup handler)
             self.assertFalse(d.called)
-            self.assertEqual(0, len(d.callbacks))
+            self.assertEqual(1, len(d.callbacks))
 
             # neither reactor.run() NOR reactor.stop() should have been called
             # (just connectTCP() will have been called)

--- a/autobahn/wamp/interfaces.py
+++ b/autobahn/wamp/interfaces.py
@@ -303,6 +303,8 @@ class ISession(object):
         :param message: An optional (human readable) closing message, intended for
                         logging purposes.
         :type message: str
+
+        :return: may return a Future/Deferred that fires when we've disconnected
         """
 
     @abc.abstractmethod

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -978,6 +978,8 @@ class ApplicationSession(BaseSession):
             msg = wamp.message.Goodbye(reason=reason, message=log_message)
             self._transport.send(msg)
             self._goodbye_sent = True
+            # deferred that fires when transport actually hits CLOSED
+            return self._transport.is_closed
         else:
             raise SessionNotReady(u"Already requested to close the session")
 

--- a/autobahn/wamp/test/test_runner.py
+++ b/autobahn/wamp/test/test_runner.py
@@ -117,7 +117,7 @@ else:
             ApplicationRunner.
             '''
             loop = Mock()
-            loop.create_connection = Mock()
+            loop.run_until_complete = Mock(return_value=(Mock(), Mock()))
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 ssl = {}
                 runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm',
@@ -132,7 +132,7 @@ else:
             ApplicationRunner and the websocket URL starts with "ws:".
             '''
             loop = Mock()
-            loop.create_connection = Mock()
+            loop.run_until_complete = Mock(return_value=(Mock(), Mock()))
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('ws://127.0.0.1:8080/ws', 'realm')
                 runner.run('_unused_')
@@ -145,7 +145,7 @@ else:
             ApplicationRunner and the websocket URL starts with "wss:".
             '''
             loop = Mock()
-            loop.create_connection = Mock()
+            loop.run_until_complete = Mock(return_value=(Mock(), Mock()))
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('wss://127.0.0.1:8080/wss', 'realm')
                 runner.run('_unused_')
@@ -157,7 +157,7 @@ else:
             but only a "ws:" URL.
             '''
             loop = Mock()
-            loop.create_connection = Mock()
+            loop.run_until_complete = Mock(return_value=(Mock(), Mock()))
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
                                            ssl=True)
@@ -190,7 +190,7 @@ else:
                 context = ssl.create_default_context()
 
             loop = Mock()
-            loop.create_connection = Mock()
+            loop.run_until_complete = Mock(return_value=(Mock(), Mock()))
             with patch.object(asyncio, 'get_event_loop', return_value=loop):
                 runner = ApplicationRunner('ws://127.0.0.1:8080/wss', 'realm',
                                            ssl=context)

--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import traceback
 
@@ -79,9 +79,8 @@ class WampWebSocketProtocol(object):
                     print("WAMP-over-WebSocket transport lost: wasClean = {0}, code = {1}, reason = '{2}'".format(wasClean, code, reason))
                 self._session.onClose(wasClean)
             except Exception:
-                # silently ignore exceptions raised here ..
-                if self.factory.debug_wamp:
-                    traceback.print_exc()
+                print("Error invoking onClose():")
+                traceback.print_exc()
             self._session = None
 
     def onMessage(self, payload, isBinary):


### PR DESCRIPTION
If you SIGTERM or ctrl-C something from `ApplicationRunner.run()` they do not wait for the Goodbye message to go out before exiting.

This lets both runners wait properly by returning a future/deferred from `leave()`.