### PR TITLE
configurable transports

### DIFF
--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -66,6 +66,68 @@ class ApplicationSessionFactory(protocol.ApplicationSessionFactory):
    """
 
 
+def _create_tcp4_stream_transport(loop, apprunner, wamp_transport_factory, **kw):
+    """
+    The default callable used for _create_stream_transport in
+    ApplicationRunner, this will parse the provided websocket URL and
+    connect via TCP4 (with TLS if it's a `wss://` URL).
+    """
+
+    isSecure, host, port, resource, path, params = parseWsUrl(apprunner.url)
+
+    if apprunner.ssl is None:
+        ssl = isSecure
+    else:
+        if apprunner.ssl and not isSecure:
+            raise RuntimeError(
+                'ssl argument value passed to %s conflicts with the "ws:" '
+                'prefix of the url argument. Did you mean to use "wss:"?' %
+                apprunner.__class__.__name__)
+        ssl = apprunner.ssl
+
+    coro = loop.create_connection(wamp_transport_factory, host, port, ssl=ssl)
+    return asyncio.async(coro)
+
+
+def _create_unix_stream_transport(loop, apprunner, wamp_transport_factory, **kw):
+    """
+    Connects to a Unix socket as the transport. You must pass the
+    socket path as `socket_path=` kwarg to `ApplicationRunner.run()`
+    """
+
+    try:
+        socket_path = kw['socket_path']
+    except KeyError:
+        raise RuntimeError("Pass socket_path= kwarg to ApplicationRunner.run()")
+
+    url = None  # see autobahn.websocket.protocol.WebSocketClientFactory
+
+    if apprunner.ssl is not None:
+        raise RuntimeError('ssl= argument inconsistent with Unix-domain sockets')
+
+    coro = loop.create_unix_connection(wamp_transport_factory, socket_path)
+    return asyncio.async(coro)
+
+
+def _create_websocket_wamp_factory(reactor, apprunner, session_factory, **kw):
+    # factory for using ApplicationSession
+    def create():
+        cfg = ComponentConfig(apprunner.realm, apprunner.extra)
+        try:
+            session = session_factory(cfg)
+        except Exception as e:
+            print(e)
+            asyncio.get_event_loop().stop()
+        else:
+            session.debug_app = apprunner.debug_app
+            return session
+
+    return WampWebSocketClientFactory(
+        create, url=apprunner.url, serializers=apprunner.serializers,
+        debug=apprunner.debug, debug_wamp=apprunner.debug_wamp
+    )
+
+
 class ApplicationRunner(object):
     """
     This class is a convenience tool mainly for development and quick hosting
@@ -77,7 +139,8 @@ class ApplicationRunner(object):
 
     def __init__(self, url, realm, extra=None, serializers=None,
                  debug=False, debug_wamp=False, debug_app=False,
-                 ssl=None):
+                 ssl=None,
+                 _create_stream_transport=None, _create_wamp_factory=None):
         """
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
         :type url: unicode
@@ -106,6 +169,36 @@ class ApplicationRunner(object):
            method, to which this value is passed as the ``ssl=``
            kwarg.
         :type ssl: :class:`ssl.SSLContext` or bool
+
+        :param _create_stream_transport:
+            A callable that takes two arguments `(apprunner,
+            wamp_transport_factory)` and must accept any
+            `kwargs`. Should be a coroutine or return a Future that fires with a
+            connected protocol.
+
+            Any kwargs passed to ApplicationRunner.run() are passed on
+            to this method.
+
+            **NOTE**: This API is currently in flux and may change,
+            hence the leading underscore. However, this allows
+            flexibility in creating the underlying transport.
+
+            Currently the following options are provided:
+
+            - `None`: (the default) creates a TCP4 (optionally with
+              TLS) transport unless `url` is None, in which case a
+              UNIX transport is created instead
+
+            - `_create_unix_stream_transport`: creates a Unix-socket
+              connection (needs `socket_path=` passed to run())
+        :type _create_stream_transport: callable
+
+        :param _create_wamp_factory:
+            A callable that takes the ApplicationRunner instance and a
+            session-creation method (e.g. ApplicationSession) and
+            returns a new transport factory. This is subsequently passed to the
+            `_create_stream_transport` callable. For Twisted this must
+            implement :tx:`twisted.internet.interfaces.IProtocolFactory`.
         """
         self.url = url
         self.realm = realm
@@ -116,8 +209,13 @@ class ApplicationRunner(object):
         self.make = None
         self.serializers = serializers
         self.ssl = ssl
+        self._create_stream_transport = _create_stream_transport or _create_tcp4_stream_transport
+        # since a None URL is used by autobahn.websocket.protocol.WebSocketClientFactory
+        if _create_stream_transport is None and url is None:
+            self._create_stream_transport = _create_unix_stream_transport
+        self._create_wamp_factory = _create_wamp_factory or _create_websocket_wamp_factory
 
-    def run(self, make):
+    def run(self, make, **kw):
         """
         Run the application component.
 
@@ -125,49 +223,33 @@ class ApplicationRunner(object):
            when called with an instance of :class:`autobahn.wamp.types.ComponentConfig`.
         :type make: callable
         """
-        # 1) factory for use ApplicationSession
-        def create():
-            cfg = ComponentConfig(self.realm, self.extra)
-            try:
-                session = make(cfg)
-            except Exception as e:
-                # the app component could not be created .. fatal
-                print(e)
-                asyncio.get_event_loop().stop()
-            else:
-                session.debug_app = self.debug_app
-                return session
 
-        isSecure, host, port, resource, path, params = parseWsUrl(self.url)
-
-        if self.ssl is None:
-            ssl = isSecure
-        else:
-            if self.ssl and not isSecure:
-                raise RuntimeError(
-                    'ssl argument value passed to %s conflicts with the "ws:" '
-                    'prefix of the url argument. Did you mean to use "wss:"?' %
-                    self.__class__.__name__)
-            ssl = self.ssl
-
-        # 2) create a WAMP-over-WebSocket transport client factory
-        transport_factory = WampWebSocketClientFactory(create, url=self.url, serializers=self.serializers,
-                                                       debug=self.debug, debug_wamp=self.debug_wamp)
-
-        # 3) start the client
+        # set up the event-loop and ensure txaio is using the same one
         loop = asyncio.get_event_loop()
         txaio.use_asyncio()
         txaio.config.loop = loop
-        coro = loop.create_connection(transport_factory, host, port, ssl=ssl)
-        (transport, protocol) = loop.run_until_complete(coro)
+
+        # want to shut down nicely on TERM
         loop.add_signal_handler(signal.SIGTERM, loop.stop)
 
-        # 4) now enter the asyncio event loop
+        # create our connection; this is some WAMP dialect over an
+        # underlying stream transport.
+        transport_factory = self._create_wamp_factory(loop, self, make, **kw)
+        d = self._create_stream_transport(loop, self, transport_factory, **kw)
+        (transport, protocol) = loop.run_until_complete(d)
+
+        # now enter the asyncio event loop
         try:
             loop.run_forever()
         except KeyboardInterrupt:
             # wait until we send Goodbye if user hit ctrl-c
             # (done outside this except so SIGTERM gets the same handling)
             pass
-        loop.run_until_complete(protocol._session.leave())
+
+        # if we still have a session hanging around, give it a chance
+        # to disconnect properly.
+        if hasattr(protocol, '_session') and protocol._session:
+            loop.run_until_complete(protocol._session.leave())
+
+        # exit
         loop.close()

--- a/autobahn/asyncio/wamp.py
+++ b/autobahn/asyncio/wamp.py
@@ -66,68 +66,6 @@ class ApplicationSessionFactory(protocol.ApplicationSessionFactory):
    """
 
 
-def _create_tcp4_stream_transport(loop, apprunner, wamp_transport_factory, **kw):
-    """
-    The default callable used for _create_stream_transport in
-    ApplicationRunner, this will parse the provided websocket URL and
-    connect via TCP4 (with TLS if it's a `wss://` URL).
-    """
-
-    isSecure, host, port, resource, path, params = parseWsUrl(apprunner.url)
-
-    if apprunner.ssl is None:
-        ssl = isSecure
-    else:
-        if apprunner.ssl and not isSecure:
-            raise RuntimeError(
-                'ssl argument value passed to %s conflicts with the "ws:" '
-                'prefix of the url argument. Did you mean to use "wss:"?' %
-                apprunner.__class__.__name__)
-        ssl = apprunner.ssl
-
-    coro = loop.create_connection(wamp_transport_factory, host, port, ssl=ssl)
-    return asyncio.async(coro)
-
-
-def _create_unix_stream_transport(loop, apprunner, wamp_transport_factory, **kw):
-    """
-    Connects to a Unix socket as the transport. You must pass the
-    socket path as `socket_path=` kwarg to `ApplicationRunner.run()`
-    """
-
-    try:
-        socket_path = kw['socket_path']
-    except KeyError:
-        raise RuntimeError("Pass socket_path= kwarg to ApplicationRunner.run()")
-
-    url = None  # see autobahn.websocket.protocol.WebSocketClientFactory
-
-    if apprunner.ssl is not None:
-        raise RuntimeError('ssl= argument inconsistent with Unix-domain sockets')
-
-    coro = loop.create_unix_connection(wamp_transport_factory, socket_path)
-    return asyncio.async(coro)
-
-
-def _create_websocket_wamp_factory(reactor, apprunner, session_factory, **kw):
-    # factory for using ApplicationSession
-    def create():
-        cfg = ComponentConfig(apprunner.realm, apprunner.extra)
-        try:
-            session = session_factory(cfg)
-        except Exception as e:
-            print(e)
-            asyncio.get_event_loop().stop()
-        else:
-            session.debug_app = apprunner.debug_app
-            return session
-
-    return WampWebSocketClientFactory(
-        create, url=apprunner.url, serializers=apprunner.serializers,
-        debug=apprunner.debug, debug_wamp=apprunner.debug_wamp
-    )
-
-
 class ApplicationRunner(object):
     """
     This class is a convenience tool mainly for development and quick hosting
@@ -139,8 +77,7 @@ class ApplicationRunner(object):
 
     def __init__(self, url, realm, extra=None, serializers=None,
                  debug=False, debug_wamp=False, debug_app=False,
-                 ssl=None,
-                 _create_stream_transport=None, _create_wamp_factory=None):
+                 ssl=None, socket_path=None):
         """
         :param url: The WebSocket URL of the WAMP router to connect to (e.g. `ws://somehost.com:8090/somepath`)
         :type url: unicode
@@ -169,36 +106,6 @@ class ApplicationRunner(object):
            method, to which this value is passed as the ``ssl=``
            kwarg.
         :type ssl: :class:`ssl.SSLContext` or bool
-
-        :param _create_stream_transport:
-            A callable that takes two arguments `(apprunner,
-            wamp_transport_factory)` and must accept any
-            `kwargs`. Should be a coroutine or return a Future that fires with a
-            connected protocol.
-
-            Any kwargs passed to ApplicationRunner.run() are passed on
-            to this method.
-
-            **NOTE**: This API is currently in flux and may change,
-            hence the leading underscore. However, this allows
-            flexibility in creating the underlying transport.
-
-            Currently the following options are provided:
-
-            - `None`: (the default) creates a TCP4 (optionally with
-              TLS) transport unless `url` is None, in which case a
-              UNIX transport is created instead
-
-            - `_create_unix_stream_transport`: creates a Unix-socket
-              connection (needs `socket_path=` passed to run())
-        :type _create_stream_transport: callable
-
-        :param _create_wamp_factory:
-            A callable that takes the ApplicationRunner instance and a
-            session-creation method (e.g. ApplicationSession) and
-            returns a new transport factory. This is subsequently passed to the
-            `_create_stream_transport` callable. For Twisted this must
-            implement :tx:`twisted.internet.interfaces.IProtocolFactory`.
         """
         self.url = url
         self.realm = realm
@@ -209,19 +116,30 @@ class ApplicationRunner(object):
         self.make = None
         self.serializers = serializers
         self.ssl = ssl
-        self._create_stream_transport = _create_stream_transport or _create_tcp4_stream_transport
-        # since a None URL is used by autobahn.websocket.protocol.WebSocketClientFactory
-        if _create_stream_transport is None and url is None:
-            self._create_stream_transport = _create_unix_stream_transport
-        self._create_wamp_factory = _create_wamp_factory or _create_websocket_wamp_factory
+        self._socket_path = socket_path
 
-    def run(self, make, **kw):
+        # configure our internal helpers for creating stream and WAMP
+        # transports
+        self._create_stream_transport = self._create_tcp4_stream_transport
+        # since a None URL is used by autobahn.websocket.protocol.WebSocketClientFactory
+        if url is None:
+            if socket_path is None:
+                raise RuntimeError("Must pass socket_path= kwarg if url is None")
+            self._create_stream_transport = self._create_unix_stream_transport
+        self._create_wamp_factory = self._create_websocket_wamp_factory
+
+    def run(self, make):
         """
         Run the application component.
 
         :param make: A factory that produces instances of :class:`autobahn.asyncio.wamp.ApplicationSession`
            when called with an instance of :class:`autobahn.wamp.types.ComponentConfig`.
         :type make: callable
+
+        :param socket_path: If you passed None as the URL, you must
+            pass socket_path= to tell ApplicationRunner where your
+            unix-socket is.
+        :type socket_path: unicode
         """
 
         # set up the event-loop and ensure txaio is using the same one
@@ -234,8 +152,8 @@ class ApplicationRunner(object):
 
         # create our connection; this is some WAMP dialect over an
         # underlying stream transport.
-        transport_factory = self._create_wamp_factory(loop, self, make, **kw)
-        d = self._create_stream_transport(loop, self, transport_factory, **kw)
+        transport_factory = self._create_wamp_factory(loop, make)
+        d = self._create_stream_transport(loop, transport_factory)
         (transport, protocol) = loop.run_until_complete(d)
 
         # now enter the asyncio event loop
@@ -253,3 +171,61 @@ class ApplicationRunner(object):
 
         # exit
         loop.close()
+
+
+    def _create_tcp4_stream_transport(self, loop, wamp_transport_factory):
+        """
+        Internal helper.
+
+        Creates a TCP4 (possibly with TLS) stream transport.
+        """
+
+        isSecure, host, port, resource, path, params = parseWsUrl(self.url)
+
+        if self.ssl is None:
+            ssl = isSecure
+        else:
+            if self.ssl and not isSecure:
+                raise RuntimeError(
+                    'ssl argument value passed to %s conflicts with the "ws:" '
+                    'prefix of the url argument. Did you mean to use "wss:"?' %
+                    self.__class__.__name__)
+            ssl = self.ssl
+
+        coro = loop.create_connection(wamp_transport_factory, host, port, ssl=ssl)
+        return asyncio.async(coro)
+
+
+    def _create_unix_stream_transport(self, loop, wamp_transport_factory):
+        """
+        Internal helper.
+
+        Creates a Unix socket as the stream transport.
+        """
+
+        url = None  # see autobahn.websocket.protocol.WebSocketClientFactory
+
+        if self.ssl is not None:
+            raise RuntimeError('ssl= argument inconsistent with Unix-domain sockets')
+
+        coro = loop.create_unix_connection(wamp_transport_factory, self._socket_path)
+        return asyncio.async(coro)
+
+
+    def _create_websocket_wamp_factory(self, loop, session_factory, **kw):
+        # factory for using ApplicationSession
+        def create():
+            cfg = ComponentConfig(self.realm, self.extra)
+            try:
+                session = session_factory(cfg)
+            except Exception as e:
+                print(e)
+                asyncio.get_event_loop().stop()
+            else:
+                session.debug_app = self.debug_app
+                return session
+
+        return WampWebSocketClientFactory(
+            create, url=self.url, serializers=self.serializers,
+            debug=self.debug, debug_wamp=self.debug_wamp
+        )


### PR DESCRIPTION
Here is *one* idea for configuring the transports for ApplicationRunner to get some discussion going about how to support #409. For context, this is a bit bigger than *just* unix-domain sockets -- there are two transports involved:

- the "stream transport" (e.g. TCP4 vs. Unix socket)
- the "WAMP transport" (e.g. web socket vs raw socket)

Both of these can have additional options (e.g. timeout options, TLS options, etc). For those unfamiliar with Twisted, they have a concept of "endpoints" that can be configured with arbitrary strings, which is exposed here -- however simply adding an "endpoint=" kwarg to ApplicationRunner leaves asyncio in the cold.

I will post some example code using this branch with both asyncio and Twisted in the PR comments.