### PR TITLE
sequential id generation

### DIFF
--- a/autobahn/twisted/rawsocket.py
+++ b/autobahn/twisted/rawsocket.py
@@ -120,6 +120,7 @@ class WampRawSocketProtocol(Int32StringReceiver):
                 self._session.onMessage(msg)
 
         except ProtocolError as e:
+            log.msg(str(e))
             if self.factory.debug:
                 log.msg("WampRawSocketProtocol: WAMP Protocol Error ({0}) - aborting connection".format(e))
             self.abort()

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -251,6 +251,8 @@ class BaseSession(object):
     This class implements :class:`autobahn.wamp.interfaces.ISession`.
     """
 
+    _MAX_REQUEST_ID = 2**53  #: request-IDs wrap here
+
     def __init__(self):
         """
 
@@ -281,6 +283,11 @@ class BaseSession(object):
         self._authrole = None
         self._authmethod = None
         self._authprovider = None
+
+        # we create sequential request-IDs for WAMP "Request" types
+        # (session-scoped) only starting at 0, but pre-increment then
+        # return.
+        self._request_id = -1
 
     def onConnect(self):
         """
@@ -314,6 +321,15 @@ class BaseSession(object):
             assert(not hasattr(exception, '_wampuris'))
             self._ecls_to_uri_pat[exception] = [uri.Pattern(six.u(error), uri.Pattern.URI_TARGET_HANDLER)]
             self._uri_to_ecls[six.u(error)] = exception
+
+    def _next_request_id(self):
+        """
+        Internal use; returns the next Session-scoped request ID.
+        """
+        self._request_id +=1
+        if self._request_id > self._MAX_REQUEST_ID:
+            self._request_id = 0
+        return self._request_id
 
     def _message_from_exception(self, request_type, request, exc, tb=None):
         """
@@ -994,7 +1010,7 @@ class ApplicationSession(BaseSession):
         if not self._transport:
             raise exception.TransportLost()
 
-        request_id = util.id()
+        request_id = self._next_request_id()
 
         if 'options' in kwargs and isinstance(kwargs['options'], types.PublishOptions):
             options = kwargs.pop('options')
@@ -1041,7 +1057,7 @@ class ApplicationSession(BaseSession):
             raise exception.TransportLost()
 
         def _subscribe(obj, fn, topic, options):
-            request_id = util.id()
+            request_id = self._next_request_id()
             on_reply = txaio.create_future()
             handler_obj = Handler(fn, obj, options.details_arg if options else None)
             self._subscribe_reqs[request_id] = SubscribeRequest(request_id, on_reply, handler_obj)
@@ -1095,7 +1111,7 @@ class ApplicationSession(BaseSession):
 
         if scount == 0:
             # if the last handler was removed, unsubscribe from broker ..
-            request_id = util.id()
+            request_id = self._next_request_id()
 
             on_reply = txaio.create_future()
             self._unsubscribe_reqs[request_id] = UnsubscribeRequest(request_id, on_reply, subscription.id)
@@ -1119,7 +1135,7 @@ class ApplicationSession(BaseSession):
         if not self._transport:
             raise exception.TransportLost()
 
-        request_id = util.id()
+        request_id = self._next_request_id()
 
         if 'options' in kwargs and isinstance(kwargs['options'], types.CallOptions):
             options = kwargs.pop('options')
@@ -1168,7 +1184,7 @@ class ApplicationSession(BaseSession):
             raise exception.TransportLost()
 
         def _register(obj, fn, procedure, options):
-            request_id = util.id()
+            request_id = self._next_request_id()
             on_reply = txaio.create_future()
             endpoint_obj = Endpoint(fn, obj, options.details_arg if options else None)
             self._register_reqs[request_id] = RegisterRequest(request_id, on_reply, procedure, endpoint_obj)
@@ -1212,7 +1228,7 @@ class ApplicationSession(BaseSession):
         if not self._transport:
             raise exception.TransportLost()
 
-        request_id = util.id()
+        request_id = self._next_request_id()
 
         on_reply = txaio.create_future()
         self._unregister_reqs[request_id] = UnregisterRequest(request_id, on_reply, registration.id)

--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -40,7 +40,6 @@ from autobahn.wamp.interfaces import ISession, \
     IRegistration, \
     ITransportHandler
 
-from autobahn import util
 from autobahn import wamp
 from autobahn.wamp import uri
 from autobahn.wamp import message

--- a/autobahn/wamp/test/test_protocol.py
+++ b/autobahn/wamp/test/test_protocol.py
@@ -33,7 +33,7 @@ if os.environ.get('USE_TWISTED', False):
     from twisted.trial import unittest
     # import unittest
 
-    from twisted.internet.defer import inlineCallbacks, Deferred, returnValue, succeed
+    from twisted.internet.defer import inlineCallbacks, Deferred, returnValue, succeed, DeferredList
     from twisted.python import log, compat
 
     from autobahn.wamp import message
@@ -42,7 +42,6 @@ if os.environ.get('USE_TWISTED', False):
     from autobahn import util
     from autobahn.wamp.exception import ApplicationError, NotAuthorized, InvalidUri, ProtocolError
     from autobahn.wamp import types
-
     from autobahn.twisted.wamp import ApplicationSession
 
     if compat._PY3:
@@ -67,6 +66,7 @@ if os.environ.get('USE_TWISTED', False):
 
             msg = message.Welcome(self._my_session_id, roles)
             self._handler.onMessage(msg)
+            self._fake_router_session = ApplicationSession()
 
         def send(self, msg):
             if self._log:
@@ -78,7 +78,7 @@ if os.environ.get('USE_TWISTED', False):
             if isinstance(msg, message.Publish):
                 if msg.topic.startswith(u'com.myapp'):
                     if msg.acknowledge:
-                        reply = message.Published(msg.request, util.id())
+                        reply = message.Published(msg.request, self._fake_router_session._next_request_id())
                 elif len(msg.topic) == 0:
                     reply = message.Error(message.Publish.MESSAGE_TYPE, msg.request, u'wamp.error.invalid_uri')
                 else:
@@ -94,7 +94,9 @@ if os.environ.get('USE_TWISTED', False):
 
                 elif msg.procedure.startswith(u'com.myapp.myproc'):
                     registration = self._registrations[msg.procedure]
-                    request = util.id()
+                    request = self._fake_router_session._next_request_id()
+                    if request in self._invocations:
+                        raise ProtocolError("duplicate invocation")
                     self._invocations[request] = msg.request
                     reply = message.Invocation(
                         request, registration,
@@ -115,7 +117,7 @@ if os.environ.get('USE_TWISTED', False):
                 if topic in self._subscription_topics:
                     reply_id = self._subscription_topics[topic]
                 else:
-                    reply_id = util.id()
+                    reply_id = self._fake_router_session._next_request_id()
                     self._subscription_topics[topic] = reply_id
                 reply = message.Subscribed(msg.request, reply_id)
 
@@ -123,7 +125,7 @@ if os.environ.get('USE_TWISTED', False):
                 reply = message.Unsubscribed(msg.request)
 
             elif isinstance(msg, message.Register):
-                registration = util.id()
+                registration = self._fake_router_session._next_request_id()
                 self._registrations[msg.procedure] = registration
                 reply = message.Registered(msg.request, registration)
 
@@ -543,6 +545,55 @@ if os.environ.get('USE_TWISTED', False):
 
             res = yield handler.call(u'com.myapp.myproc1')
             self.assertEqual(res, 23)
+
+        @inlineCallbacks
+        def test_invoke_twice(self):
+            handler = ApplicationSession()
+            MockTransport(handler)
+
+            def myproc1():
+                return 23
+
+            yield handler.register(myproc1, u'com.myapp.myproc1')
+
+            d0 = handler.call(u'com.myapp.myproc1')
+            d1 = handler.call(u'com.myapp.myproc1')
+            res = yield DeferredList([d0, d1])
+            self.assertEqual(res, [(True, 23), (True, 23)])
+
+        @inlineCallbacks
+        def test_invoke_request_id_sequences(self):
+            """
+            make sure each session independently generates sequential IDs
+            """
+            handler0 = ApplicationSession()
+            handler1 = ApplicationSession()
+            trans0 = MockTransport(handler0)
+            trans1 = MockTransport(handler1)
+
+            # the ID sequences for each session should both start at 0
+            # (the register) and then increment for the call()
+            def verify_seq_id(orig, msg):
+                if isinstance(msg, message.Register):
+                    self.assertEqual(msg.request, 0)
+                elif isinstance(msg, message.Call):
+                    self.assertEqual(msg.request, 1)
+                return orig(msg)
+            orig0 = trans0.send
+            orig1 = trans1.send
+            trans0.send = lambda msg: verify_seq_id(orig0, msg)
+            trans1.send = lambda msg: verify_seq_id(orig1, msg)
+
+            def myproc1():
+                return 23
+
+            yield handler0.register(myproc1, u'com.myapp.myproc1')
+            yield handler1.register(myproc1, u'com.myapp.myproc1')
+
+            d0 = handler0.call(u'com.myapp.myproc1')
+            d1 = handler1.call(u'com.myapp.myproc1')
+            res = yield DeferredList([d0, d1])
+            self.assertEqual(res, [(True, 23), (True, 23)])
 
         @inlineCallbacks
         def test_invoke_user_raises(self):

--- a/autobahn/wamp/websocket.py
+++ b/autobahn/wamp/websocket.py
@@ -94,6 +94,7 @@ class WampWebSocketProtocol(object):
                 self._session.onMessage(msg)
 
         except ProtocolError as e:
+            print(e)
             if self.factory.debug_wamp:
                 traceback.print_exc()
             reason = "WAMP Protocol Error ({0})".format(e)


### PR DESCRIPTION
Adds a sequential ID generator in BaseSession (that wraps at 2**53) to provide IDs for all the Request (session-scoped IDs) replacing use of util.id() for these IDs. Issue #419