### PR TITLE
Update calculator example to remove standalone wamp router

### DIFF
--- a/examples/twisted/wamp/app/calculator/calculator.py
+++ b/examples/twisted/wamp/app/calculator/calculator.py
@@ -24,14 +24,14 @@
 #
 ###############################################################################
 
+from os import environ
 import sys
 import decimal
 
 from twisted.internet.defer import inlineCallbacks
 
 from autobahn import wamp
-from autobahn.twisted.wamp import ApplicationSession
-
+from autobahn.twisted.wamp import ApplicationSession, ApplicationRunner
 
 class Calculator(ApplicationSession):
 
@@ -97,29 +97,14 @@ if __name__ == '__main__':
         from twisted.python import log
         log.startLogging(sys.stdout)
 
-    # import Twisted reactor
-    ##
-    from twisted.internet import reactor
-    print("Using Twisted reactor {0}".format(reactor.__class__))
-
-    # create embedded web server for static files
-    ##
-    if args.web:
-        from twisted.web.server import Site
-        from twisted.web.static import File
-        reactor.listenTCP(args.web, Site(File(".")))
-
     # run WAMP application component
     ##
     from autobahn.twisted.wamp import ApplicationRunner
-    router = args.router or 'ws://localhost:9000'
 
-    runner = ApplicationRunner(router, u"realm1", standalone=not args.router,
-                               debug=False,             # low-level logging
-                               debug_wamp=args.debug,   # WAMP level logging
-                               debug_app=args.debug     # app-level logging
-                               )
-
-    # start the component and the Twisted reactor ..
-    ##
+    runner = ApplicationRunner(
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        u"crossbardemo",
+        debug_wamp=False,  # optional; log many WAMP details
+        debug=False,  # optional; log even more details
+    )
     runner.run(Calculator)

--- a/examples/twisted/wamp/app/calculator/index.html
+++ b/examples/twisted/wamp/app/calculator/index.html
@@ -48,16 +48,16 @@
             //
             var wsuri;
             if (document.location.origin == "file://") {
-               wsuri = "ws://localhost:9000";
+               wsuri = "ws://localhost:8080/ws";
             } else {
-               wsuri = "ws://" + document.location.hostname + ":9000";
+               wsuri = "ws://" + document.location.hostname + ":8080/ws";
             }
             
             // connect to WAMP server
             //
             var connection = new autobahn.Connection({
                url: wsuri,
-               realm: 'realm1'
+               realm: 'crossbardemo'
             });
 
             connection.onopen = function (session) {


### PR DESCRIPTION
Edited the calculator example to get it to run using the demo crossbar router used in other examples.