### PR TITLE
rename _log to _ab_log so that Twisted 15.3 works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ egg\-info
 egg
 .egg*
 .tox
+.coverage

--- a/autobahn/asyncio/websocket.py
+++ b/autobahn/asyncio/websocket.py
@@ -214,7 +214,7 @@ class WebSocketAdapterFactory(object):
     Adapter class for asyncio-based WebSocket client and server factories.
     """
 
-    def _log(self, msg):
+    def _ab_log(self, msg):
         print(msg)
 
     def __call__(self):

--- a/autobahn/twisted/websocket.py
+++ b/autobahn/twisted/websocket.py
@@ -171,7 +171,7 @@ class WebSocketServerProtocol(WebSocketAdapterProtocol, protocol.WebSocketServer
                 return self.failHandshake(failure.value.reason, failure.value.code)
             else:
                 if self.debug:
-                    self.factory._log("Unexpected exception in onConnect ['%s']" % failure.value)
+                    self.factory._ab_log("Unexpected exception in onConnect ['%s']" % failure.value)
                 return self.failHandshake(http.INTERNAL_SERVER_ERROR[1], http.INTERNAL_SERVER_ERROR[0])
 
         res.addErrback(forwardError)
@@ -191,7 +191,7 @@ class WebSocketAdapterFactory(object):
     Adapter class for Twisted-based WebSocket client and server factories.
     """
 
-    def _log(self, msg):
+    def _ab_log(self, msg):
         log.msg(msg)
 
 

--- a/autobahn/websocket/protocol.py
+++ b/autobahn/websocket/protocol.py
@@ -669,7 +669,7 @@ class WebSocketProtocol(object):
         Implements :func:`autobahn.websocket.interfaces.IWebSocketChannel.onOpen`
         """
         if self.debugCodePaths:
-            self.factory._log("WebSocketProtocol.onOpen")
+            self.factory._ab_log("WebSocketProtocol.onOpen")
 
     def onMessageBegin(self, isBinary):
         """
@@ -741,14 +741,14 @@ class WebSocketProtocol(object):
         Implements :func:`autobahn.websocket.interfaces.IWebSocketChannel.onMessage`
         """
         if self.debug:
-            self.factory._log("WebSocketProtocol.onMessage")
+            self.factory._ab_log("WebSocketProtocol.onMessage")
 
     def onPing(self, payload):
         """
         Implements :func:`autobahn.websocket.interfaces.IWebSocketChannel.onPing`
         """
         if self.debug:
-            self.factory._log("WebSocketProtocol.onPing")
+            self.factory._ab_log("WebSocketProtocol.onPing")
         if self.state == WebSocketProtocol.STATE_OPEN:
             self.sendPong(payload)
 
@@ -757,7 +757,7 @@ class WebSocketProtocol(object):
         Implements :func:`autobahn.websocket.interfaces.IWebSocketChannel.onPong`
         """
         if self.debug:
-            self.factory._log("WebSocketProtocol.onPong")
+            self.factory._ab_log("WebSocketProtocol.onPong")
 
     def onClose(self, wasClean, code, reason):
         """
@@ -777,7 +777,7 @@ class WebSocketProtocol(object):
             s += "self.localCloseReason=%s\n" % self.localCloseReason
             s += "self.remoteCloseCode=%s\n" % self.remoteCloseCode
             s += "self.remoteCloseReason=%s\n" % self.remoteCloseReason
-            self.factory._log(s)
+            self.factory._ab_log(s)
 
     def onCloseFrame(self, code, reasonRaw):
         """
@@ -798,7 +798,7 @@ class WebSocketProtocol(object):
         :type reason: str or None
         """
         if self.debugCodePaths:
-            self.factory._log("WebSocketProtocol.onCloseFrame")
+            self.factory._ab_log("WebSocketProtocol.onCloseFrame")
 
         self.remoteCloseCode = code
 
@@ -830,7 +830,7 @@ class WebSocketProtocol(object):
             #
             if self.closeHandshakeTimeoutCall is not None:
                 if self.debugCodePaths:
-                    self.factory._log("closeHandshakeTimeoutCall.cancel")
+                    self.factory._ab_log("closeHandshakeTimeoutCall.cancel")
                 self.closeHandshakeTimeoutCall.cancel()
                 self.closeHandshakeTimeoutCall = None
 
@@ -892,14 +892,14 @@ class WebSocketProtocol(object):
         self.serverConnectionDropTimeoutCall = None
         if self.state != WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("onServerConnectionDropTimeout")
+                self.factory._ab_log("onServerConnectionDropTimeout")
             self.wasClean = False
             self.wasNotCleanReason = "server did not drop TCP connection (in time)"
             self.wasServerConnectionDropTimeout = True
             self.dropConnection(abort=True)
         else:
             if self.debugCodePaths:
-                self.factory._log("skipping onServerConnectionDropTimeout since connection is already closed")
+                self.factory._ab_log("skipping onServerConnectionDropTimeout since connection is already closed")
 
     def onOpenHandshakeTimeout(self):
         """
@@ -912,20 +912,20 @@ class WebSocketProtocol(object):
         self.openHandshakeTimeoutCall = None
         if self.state in [WebSocketProtocol.STATE_CONNECTING, WebSocketProtocol.STATE_PROXY_CONNECTING]:
             if self.debugCodePaths:
-                self.factory._log("onOpenHandshakeTimeout fired")
+                self.factory._ab_log("onOpenHandshakeTimeout fired")
             self.wasClean = False
             self.wasNotCleanReason = "peer did not finish (in time) the opening handshake"
             self.wasOpenHandshakeTimeout = True
             self.dropConnection(abort=True)
         elif self.state == WebSocketProtocol.STATE_OPEN:
             if self.debugCodePaths:
-                self.factory._log("skipping onOpenHandshakeTimeout since WebSocket connection is open (opening handshake already finished)")
+                self.factory._ab_log("skipping onOpenHandshakeTimeout since WebSocket connection is open (opening handshake already finished)")
         elif self.state == WebSocketProtocol.STATE_CLOSING:
             if self.debugCodePaths:
-                self.factory._log("skipping onOpenHandshakeTimeout since WebSocket connection is closing")
+                self.factory._ab_log("skipping onOpenHandshakeTimeout since WebSocket connection is closing")
         elif self.state == WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("skipping onOpenHandshakeTimeout since WebSocket connection already closed")
+                self.factory._ab_log("skipping onOpenHandshakeTimeout since WebSocket connection already closed")
         else:
             # should not arrive here
             raise Exception("logic error")
@@ -941,14 +941,14 @@ class WebSocketProtocol(object):
         self.closeHandshakeTimeoutCall = None
         if self.state != WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("onCloseHandshakeTimeout fired")
+                self.factory._ab_log("onCloseHandshakeTimeout fired")
             self.wasClean = False
             self.wasNotCleanReason = "peer did not respond (in time) in closing handshake"
             self.wasCloseHandshakeTimeout = True
             self.dropConnection(abort=True)
         else:
             if self.debugCodePaths:
-                self.factory._log("skipping onCloseHandshakeTimeout since connection is already closed")
+                self.factory._ab_log("skipping onCloseHandshakeTimeout since connection is already closed")
 
     def onAutoPingTimeout(self):
         """
@@ -956,7 +956,7 @@ class WebSocketProtocol(object):
         did not reply in time to our ping. We drop the connection.
         """
         if self.debugCodePaths:
-            self.factory._log("Auto ping/pong: onAutoPingTimeout fired")
+            self.factory._ab_log("Auto ping/pong: onAutoPingTimeout fired")
 
         self.autoPingTimeoutCall = None
         self.dropConnection(abort=True)
@@ -969,7 +969,7 @@ class WebSocketProtocol(object):
         """
         if self.state != WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("dropping connection")
+                self.factory._ab_log("dropping connection")
             self.droppedByMe = True
 
             # this code-path will be hit (*without* hitting
@@ -981,7 +981,7 @@ class WebSocketProtocol(object):
             self._closeConnection(abort)
         else:
             if self.debugCodePaths:
-                self.factory._log("skipping dropConnection since connection is already closed")
+                self.factory._ab_log("skipping dropConnection since connection is already closed")
 
     def failConnection(self, code=CLOSE_STATUS_CODE_GOING_AWAY, reason="Going Away"):
         """
@@ -994,7 +994,7 @@ class WebSocketProtocol(object):
         """
         if self.state != WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("Failing connection : %s - %s" % (code, reason))
+                self.factory._ab_log("Failing connection : %s - %s" % (code, reason))
 
             self.failedByMe = True
 
@@ -1015,7 +1015,7 @@ class WebSocketProtocol(object):
 
         else:
             if self.debugCodePaths:
-                self.factory._log("skipping failConnection since connection is already closed")
+                self.factory._ab_log("skipping failConnection since connection is already closed")
 
     def protocolViolation(self, reason):
         """
@@ -1032,7 +1032,7 @@ class WebSocketProtocol(object):
         :returns: bool -- True, when any further processing should be discontinued.
         """
         if self.debugCodePaths:
-            self.factory._log("Protocol violation : %s" % reason)
+            self.factory._ab_log("Protocol violation : %s" % reason)
         self.failConnection(WebSocketProtocol.CLOSE_STATUS_CODE_PROTOCOL_ERROR, reason)
         if self.failByDrop:
             return True
@@ -1058,7 +1058,7 @@ class WebSocketProtocol(object):
         :returns: bool -- True, when any further processing should be discontinued.
         """
         if self.debugCodePaths:
-            self.factory._log("Invalid payload : %s" % reason)
+            self.factory._ab_log("Invalid payload : %s" % reason)
         self.failConnection(WebSocketProtocol.CLOSE_STATUS_CODE_INVALID_PAYLOAD, reason)
         if self.failByDrop:
             return True
@@ -1103,8 +1103,8 @@ class WebSocketProtocol(object):
             configAttrLog.append((configAttr, getattr(self, configAttr), configAttrSource))
 
         if self.debug:
-            # self.factory._log(configAttrLog)
-            self.factory._log("\n" + pformat(configAttrLog))
+            # self.factory._ab_log(configAttrLog)
+            self.factory._ab_log("\n" + pformat(configAttrLog))
 
         # permessage-compress extension
         self._perMessageCompress = None
@@ -1209,7 +1209,7 @@ class WebSocketProtocol(object):
         #
         if not self.factory.isServer and self.serverConnectionDropTimeoutCall is not None:
             if self.debugCodePaths:
-                self.factory._log("serverConnectionDropTimeoutCall.cancel")
+                self.factory._ab_log("serverConnectionDropTimeoutCall.cancel")
             self.serverConnectionDropTimeoutCall.cancel()
             self.serverConnectionDropTimeoutCall = None
 
@@ -1217,13 +1217,13 @@ class WebSocketProtocol(object):
         #
         if self.autoPingPendingCall:
             if self.debugCodePaths:
-                self.factory._log("Auto ping/pong: canceling autoPingPendingCall upon lost connection")
+                self.factory._ab_log("Auto ping/pong: canceling autoPingPendingCall upon lost connection")
             self.autoPingPendingCall.cancel()
             self.autoPingPendingCall = None
 
         if self.autoPingTimeoutCall:
             if self.debugCodePaths:
-                self.factory._log("Auto ping/pong: canceling autoPingTimeoutCall upon lost connection")
+                self.factory._ab_log("Auto ping/pong: canceling autoPingTimeoutCall upon lost connection")
             self.autoPingTimeoutCall.cancel()
             self.autoPingTimeoutCall = None
 
@@ -1235,7 +1235,7 @@ class WebSocketProtocol(object):
 
         if self.wasServingFlashSocketPolicyFile:
             if self.debug:
-                self.factory._log("connection dropped after serving Flash Socket Policy File")
+                self.factory._ab_log("connection dropped after serving Flash Socket Policy File")
         else:
             if not self.wasClean:
                 if not self.droppedByMe and self.wasNotCleanReason is None:
@@ -1250,7 +1250,7 @@ class WebSocketProtocol(object):
 
         Modes: Hybi, Hixie
         """
-        self.factory._log("RX Octets from %s : octets = %s" % (self.peer, binascii.b2a_hex(data)))
+        self.factory._ab_log("RX Octets from %s : octets = %s" % (self.peer, binascii.b2a_hex(data)))
 
     def logTxOctets(self, data, sync):
         """
@@ -1258,7 +1258,7 @@ class WebSocketProtocol(object):
 
         Modes: Hybi, Hixie
         """
-        self.factory._log("TX Octets to %s : sync = %s, octets = %s" % (self.peer, sync, binascii.b2a_hex(data)))
+        self.factory._ab_log("TX Octets to %s : sync = %s, octets = %s" % (self.peer, sync, binascii.b2a_hex(data)))
 
     def logRxFrame(self, frameHeader, payload):
         """
@@ -1275,7 +1275,7 @@ class WebSocketProtocol(object):
                 frameHeader.length,
                 data if frameHeader.opcode == 1 else binascii.b2a_hex(data))
 
-        self.factory._log("RX Frame from %s : fin = %s, rsv = %s, opcode = %s, mask = %s, length = %s, payload = %s" % info)
+        self.factory._ab_log("RX Frame from %s : fin = %s, rsv = %s, opcode = %s, mask = %s, length = %s, payload = %s" % info)
 
     def logTxFrame(self, frameHeader, payload, repeatLength, chopsize, sync):
         """
@@ -1294,7 +1294,7 @@ class WebSocketProtocol(object):
                 sync,
                 payload if frameHeader.opcode == 1 else binascii.b2a_hex(payload))
 
-        self.factory._log("TX Frame to %s : fin = %s, rsv = %s, opcode = %s, mask = %s, length = %s, repeat_length = %s, chopsize = %s, sync = %s, payload = %s" % info)
+        self.factory._ab_log("TX Frame to %s : fin = %s, rsv = %s, opcode = %s, mask = %s, length = %s, repeat_length = %s, chopsize = %s, sync = %s, payload = %s" % info)
 
     def _dataReceived(self, data):
         """
@@ -1351,7 +1351,7 @@ class WebSocketProtocol(object):
             # ignore any data received after WS was closed
             #
             if self.debugCodePaths:
-                self.factory._log("received data in STATE_CLOSED")
+                self.factory._ab_log("received data in STATE_CLOSED")
 
         # should not arrive here (invalid state)
         #
@@ -1407,7 +1407,7 @@ class WebSocketProtocol(object):
                     self.logTxOctets(e[0], e[1])
             else:
                 if self.debugCodePaths:
-                    self.factory._log("skipped delayed write, since connection is closed")
+                    self.factory._ab_log("skipped delayed write, since connection is closed")
             # we need to reenter the reactor to make the latter
             # reenter the OS network stack, so that octets
             # can get on the wire. Note: this is a "heuristic",
@@ -1854,7 +1854,7 @@ class WebSocketProtocol(object):
             if self._isMessageCompressed:
                 compressedLen = len(payload)
                 if self.debug:
-                    self.factory._log("RX compressed [%d]: %s" % (compressedLen, binascii.b2a_hex(payload)))
+                    self.factory._ab_log("RX compressed [%d]: %s" % (compressedLen, binascii.b2a_hex(payload)))
 
                 payload = self._perMessageCompress.decompressMessageData(payload)
                 uncompressedLen = len(payload)
@@ -1910,7 +1910,7 @@ class WebSocketProtocol(object):
                             return False
 
                 # if self.debug:
-                #   self.factory._log("Traffic statistics:\n" + str(self.trafficStats))
+                #   self.factory._ab_log("Traffic statistics:\n" + str(self.trafficStats))
 
                 if self.state == WebSocketProtocol.STATE_OPEN:
                     self.trafficStats.incomingWebSocketMessages += 1
@@ -1960,7 +1960,7 @@ class WebSocketProtocol(object):
                 try:
                     if payload == self.autoPingPending:
                         if self.debugCodePaths:
-                            self.factory._log("Auto ping/pong: received pending pong for auto-ping/pong")
+                            self.factory._ab_log("Auto ping/pong: received pending pong for auto-ping/pong")
 
                         if self.autoPingTimeoutCall:
                             self.autoPingTimeoutCall.cancel()
@@ -1972,10 +1972,10 @@ class WebSocketProtocol(object):
                             self.autoPingPendingCall = txaio.call_later(self.autoPingInterval, self._sendAutoPing)
                     else:
                         if self.debugCodePaths:
-                            self.factory._log("Auto ping/pong: received non-pending pong")
+                            self.factory._ab_log("Auto ping/pong: received non-pending pong")
                 except:
                     if self.debugCodePaths:
-                        self.factory._log("Auto ping/pong: received non-pending pong")
+                        self.factory._ab_log("Auto ping/pong: received non-pending pong")
 
             # fire app-level callback
             #
@@ -2103,7 +2103,7 @@ class WebSocketProtocol(object):
     def _sendAutoPing(self):
         # Sends an automatic ping and sets up a timeout.
         if self.debugCodePaths:
-            self.factory._log("Auto ping/pong: sending ping auto-ping/pong")
+            self.factory._ab_log("Auto ping/pong: sending ping auto-ping/pong")
 
         self.autoPingPendingCall = None
 
@@ -2113,7 +2113,7 @@ class WebSocketProtocol(object):
 
         if self.autoPingTimeout:
             if self.debugCodePaths:
-                self.factory._log("Auto ping/pong: expecting ping in {0} seconds for auto-ping/pong".format(self.autoPingTimeout))
+                self.factory._ab_log("Auto ping/pong: expecting ping in {0} seconds for auto-ping/pong".format(self.autoPingTimeout))
             self.autoPingTimeoutCall = txaio.call_later(self.autoPingTimeout, self.onAutoPingTimeout)
 
     def sendPong(self, payload=None):
@@ -2146,11 +2146,11 @@ class WebSocketProtocol(object):
         """
         if self.state == WebSocketProtocol.STATE_CLOSING:
             if self.debugCodePaths:
-                self.factory._log("ignoring sendCloseFrame since connection is closing")
+                self.factory._ab_log("ignoring sendCloseFrame since connection is closing")
 
         elif self.state == WebSocketProtocol.STATE_CLOSED:
             if self.debugCodePaths:
-                self.factory._log("ignoring sendCloseFrame since connection already closed")
+                self.factory._ab_log("ignoring sendCloseFrame since connection already closed")
 
         elif self.state in [WebSocketProtocol.STATE_PROXY_CONNECTING, WebSocketProtocol.STATE_CONNECTING]:
             raise Exception("cannot close a connection not yet connected")
@@ -2534,7 +2534,7 @@ class WebSocketProtocol(object):
                 i += pfs
 
         # if self.debug:
-        #   self.factory._log("Traffic statistics:\n" + str(self.trafficStats))
+        #   self.factory._ab_log("Traffic statistics:\n" + str(self.trafficStats))
 
     def _parseExtensionsHeader(self, header, removeQuotes=True):
         """
@@ -2733,7 +2733,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         WebSocketProtocol._connectionMade(self)
         self.factory.countConnections += 1
         if self.debug:
-            self.factory._log("connection accepted from peer %s" % self.peer)
+            self.factory._ab_log("connection accepted from peer %s" % self.peer)
 
     def _connectionLost(self, reason):
         """
@@ -2745,7 +2745,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         WebSocketProtocol._connectionLost(self, reason)
         self.factory.countConnections -= 1
         if self.debug:
-            self.factory._log("connection from %s lost" % self.peer)
+            self.factory._ab_log("connection from %s lost" % self.peer)
 
     def processProxyConnect(self):
         raise Exception("Autobahn isn't a proxy server")
@@ -2767,7 +2767,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
 
             self.http_request_data = self.data[:end_of_header + 4]
             if self.debug:
-                self.factory._log("received HTTP request:\n\n%s\n\n" % self.http_request_data)
+                self.factory._ab_log("received HTTP request:\n\n%s\n\n" % self.http_request_data)
 
             # extract HTTP status line and headers
             #
@@ -2776,8 +2776,8 @@ class WebSocketServerProtocol(WebSocketProtocol):
             # validate WebSocket opening handshake client request
             #
             if self.debug:
-                self.factory._log("received HTTP status line in opening handshake : %s" % str(self.http_status_line))
-                self.factory._log("received HTTP headers in opening handshake : %s" % str(self.http_headers))
+                self.factory._ab_log("received HTTP status line in opening handshake : %s" % str(self.http_status_line))
+                self.factory._ab_log("received HTTP headers in opening handshake : %s" % str(self.http_headers))
 
             # HTTP Request line : METHOD, VERSION
             #
@@ -2836,7 +2836,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
                         return self.failHandshake("port %d in HTTP Host header '%s' does not match server listening port %s" % (port, str(self.http_request_host), self.factory.externalPort))
                 else:
                     if self.debugCodePaths:
-                        self.factory._log("skipping opening handshake port checking - neither WS URL nor external port set")
+                        self.factory._ab_log("skipping opening handshake port checking - neither WS URL nor external port set")
 
                 self.http_request_host = h
 
@@ -2847,7 +2847,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
                         return self.failHandshake("missing port in HTTP Host header '%s' and server runs on non-standard port %d (wss = %s)" % (str(self.http_request_host), self.factory.externalPort, self.factory.isSecure))
                 else:
                     if self.debugCodePaths:
-                        self.factory._log("skipping opening handshake port checking - neither WS URL nor external port set")
+                        self.factory._ab_log("skipping opening handshake port checking - neither WS URL nor external port set")
 
             # Upgrade
             #
@@ -2875,15 +2875,15 @@ class WebSocketServerProtocol(WebSocketProtocol):
                         if 'after' in self.http_request_params and len(self.http_request_params['after']) > 0:
                             after = int(self.http_request_params['after'][0])
                             if self.debugCodePaths:
-                                self.factory._log("HTTP Upgrade header missing : render server status page and meta-refresh-redirecting to %s after %d seconds" % (url, after))
+                                self.factory._ab_log("HTTP Upgrade header missing : render server status page and meta-refresh-redirecting to %s after %d seconds" % (url, after))
                             self.sendServerStatus(url, after)
                         else:
                             if self.debugCodePaths:
-                                self.factory._log("HTTP Upgrade header missing : 303-redirecting to %s" % url)
+                                self.factory._ab_log("HTTP Upgrade header missing : 303-redirecting to %s" % url)
                             self.sendRedirect(url)
                     else:
                         if self.debugCodePaths:
-                            self.factory._log("HTTP Upgrade header missing : render server status page")
+                            self.factory._ab_log("HTTP Upgrade header missing : render server status page")
                         self.sendServerStatus()
                     self.dropConnection(abort=False)
                     return
@@ -2913,14 +2913,14 @@ class WebSocketServerProtocol(WebSocketProtocol):
             #
             if 'sec-websocket-version' not in self.http_headers:
                 if self.debugCodePaths:
-                    self.factory._log("Hixie76 protocol detected")
+                    self.factory._ab_log("Hixie76 protocol detected")
                 if self.allowHixie76:
                     version = 0
                 else:
                     return self.failHandshake("WebSocket connection denied - Hixie76 protocol mode disabled.")
             else:
                 if self.debugCodePaths:
-                    self.factory._log("Hybi protocol detected")
+                    self.factory._ab_log("Hybi protocol detected")
                 if http_headers_cnt["sec-websocket-version"] > 1:
                     return self.failHandshake("HTTP Sec-WebSocket-Version header appears more than once in opening handshake request")
                 try:
@@ -3038,7 +3038,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
                 else:
                     key3 = self.data[end_of_header + 4:end_of_header + 4 + 8]
                     if self.debug:
-                        self.factory._log("received HTTP request body containing key3 for Hixie-76: %s" % key3)
+                        self.factory._ab_log("received HTTP request body containing key3 for Hixie-76: %s" % key3)
 
             # Ok, got complete HS input, remember rest (if any)
             #
@@ -3085,11 +3085,11 @@ class WebSocketServerProtocol(WebSocketProtocol):
             flash_policy_file_request = self.data.find(b"<policy-file-request/>\x00")
             if flash_policy_file_request >= 0:
                 if self.debug:
-                    self.factory._log("received Flash Socket Policy File request")
+                    self.factory._ab_log("received Flash Socket Policy File request")
 
                 if self.serveFlashSocketPolicy:
                     if self.debug:
-                        self.factory._log("sending Flash Socket Policy File :\n%s" % self.flashSocketPolicy)
+                        self.factory._ab_log("sending Flash Socket Policy File :\n%s" % self.flashSocketPolicy)
 
                     self.sendData(self.flashSocketPolicy.encode('utf8'))
 
@@ -3098,7 +3098,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
                     self.dropConnection()
                 else:
                     if self.debug:
-                        self.factory._log("No Flash Policy File served. You might want to serve a Flask Socket Policy file on the destination port since you received a request for it. See WebSocketServerFactory.serveFlashSocketPolicy and WebSocketServerFactory.flashSocketPolicy")
+                        self.factory._ab_log("No Flash Policy File served. You might want to serve a Flask Socket Policy file on the destination port since you received a request for it. See WebSocketServerFactory.serveFlashSocketPolicy and WebSocketServerFactory.flashSocketPolicy")
 
     def succeedHandshake(self, res):
         """
@@ -3139,7 +3139,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         for (extension, params) in self.websocket_extensions:
 
             if self.debug:
-                self.factory._log("parsed WebSocket extension '%s' with params '%s'" % (extension, params))
+                self.factory._ab_log("parsed WebSocket extension '%s' with params '%s'" % (extension, params))
 
             # process permessage-compress extension
             #
@@ -3155,7 +3155,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
 
             else:
                 if self.debug:
-                    self.factory._log("client requested '%s' extension we don't support or which is not activated" % extension)
+                    self.factory._ab_log("client requested '%s' extension we don't support or which is not activated" % extension)
 
         # handle permessage-compress offers by the client
         #
@@ -3168,7 +3168,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
                 extensionResponse.append(accept.getExtensionString())
             else:
                 if self.debug:
-                    self.factory._log("client request permessage-compress extension, but we did not accept any offer [%s]" % pmceOffers)
+                    self.factory._ab_log("client request permessage-compress extension, but we did not accept any offer [%s]" % pmceOffers)
 
         # build response to complete WebSocket handshake
         #
@@ -3208,15 +3208,15 @@ class WebSocketServerProtocol(WebSocketProtocol):
                 response += "Sec-WebSocket-Origin: %s\x0d\x0a" % str(self.websocket_origin)
 
             if self.debugCodePaths:
-                self.factory._log('factory isSecure = %s port = %s' % (self.factory.isSecure, self.factory.externalPort))
+                self.factory._ab_log('factory isSecure = %s port = %s' % (self.factory.isSecure, self.factory.externalPort))
 
             if self.factory.externalPort and ((self.factory.isSecure and self.factory.externalPort != 443) or ((not self.factory.isSecure) and self.factory.externalPort != 80)):
                 if self.debugCodePaths:
-                    self.factory._log('factory running on non-default port')
+                    self.factory._ab_log('factory running on non-default port')
                 response_port = ':' + str(self.factory.externalPort)
             else:
                 if self.debugCodePaths:
-                    self.factory._log('factory running on default port')
+                    self.factory._ab_log('factory running on default port')
                 response_port = ''
 
             # FIXME: check this! But see below ..
@@ -3263,12 +3263,12 @@ class WebSocketServerProtocol(WebSocketProtocol):
         # send out opening handshake response
         #
         if self.debug:
-            self.factory._log("sending HTTP response:\n\n%s" % response)
+            self.factory._ab_log("sending HTTP response:\n\n%s" % response)
         self.sendData(response.encode('utf8'))
 
         if response_body:
             if self.debug:
-                self.factory._log("sending HTTP response body:\n\n%s" % binascii.b2a_hex(response_body))
+                self.factory._ab_log("sending HTTP response body:\n\n%s" % binascii.b2a_hex(response_body))
             self.sendData(response_body)
 
         # save response for testsuite
@@ -3283,7 +3283,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         #
         if self.openHandshakeTimeoutCall is not None:
             if self.debugCodePaths:
-                self.factory._log("openHandshakeTimeoutCall.cancel")
+                self.factory._ab_log("openHandshakeTimeoutCall.cancel")
             self.openHandshakeTimeoutCall.cancel()
             self.openHandshakeTimeoutCall = None
 
@@ -3315,7 +3315,7 @@ class WebSocketServerProtocol(WebSocketProtocol):
         error response and then drop the connection.
         """
         if self.debug:
-            self.factory._log("failing WebSocket opening handshake ('%s')" % reason)
+            self.factory._ab_log("failing WebSocket opening handshake ('%s')" % reason)
         self.sendHttpErrorResponse(code, reason, responseHeaders)
         self.dropConnection(abort=False)
 
@@ -3746,7 +3746,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
         """
         WebSocketProtocol._connectionMade(self)
         if self.debug:
-            self.factory._log("connection to %s established" % self.peer)
+            self.factory._ab_log("connection to %s established" % self.peer)
 
         if not self.factory.isServer and self.factory.proxy is not None:
             # start by doing a HTTP/CONNECT for explicit proxies
@@ -3764,7 +3764,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
         """
         WebSocketProtocol._connectionLost(self, reason)
         if self.debug:
-            self.factory._log("connection to %s lost" % self.peer)
+            self.factory._ab_log("connection to %s lost" % self.peer)
 
     def startProxyConnect(self):
         """
@@ -3778,7 +3778,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
         request += "\x0d\x0a"
 
         if self.debug:
-            self.factory._log(request)
+            self.factory._ab_log(request)
 
         self.sendData(request)
 
@@ -3793,7 +3793,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
 
             http_response_data = self.data[:end_of_header + 4]
             if self.debug:
-                self.factory._log("received HTTP response:\n\n%s\n\n" % http_response_data)
+                self.factory._ab_log("received HTTP response:\n\n%s\n\n" % http_response_data)
 
             # extract HTTP status line and headers
             #
@@ -3802,8 +3802,8 @@ class WebSocketClientProtocol(WebSocketProtocol):
             # validate proxy connect response
             #
             if self.debug:
-                self.factory._log("received HTTP status line for proxy connect request : %s" % str(http_status_line))
-                self.factory._log("received HTTP headers for proxy connect request : %s" % str(http_headers))
+                self.factory._ab_log("received HTTP status line for proxy connect request : %s" % str(http_status_line))
+                self.factory._ab_log("received HTTP headers for proxy connect request : %s" % str(http_headers))
 
             # Response Line
             #
@@ -3858,7 +3858,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
         connection.
         """
         if self.debug:
-            self.factory._log("failing proxy connect ('%s')" % reason)
+            self.factory._ab_log("failing proxy connect ('%s')" % reason)
         self.dropConnection(abort=True)
 
     def createHixieKey(self):
@@ -3976,7 +3976,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
             self.sendData(request_body)
 
         if self.debug:
-            self.factory._log(request)
+            self.factory._ab_log(request)
 
     def processHandshake(self):
         """
@@ -3989,7 +3989,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
 
             self.http_response_data = self.data[:end_of_header + 4]
             if self.debug:
-                self.factory._log("received HTTP response:\n\n%s\n\n" % self.http_response_data)
+                self.factory._ab_log("received HTTP response:\n\n%s\n\n" % self.http_response_data)
 
             # extract HTTP status line and headers
             #
@@ -3998,8 +3998,8 @@ class WebSocketClientProtocol(WebSocketProtocol):
             # validate WebSocket opening handshake server response
             #
             if self.debug:
-                self.factory._log("received HTTP status line in opening handshake : %s" % str(self.http_status_line))
-                self.factory._log("received HTTP headers in opening handshake : %s" % str(self.http_headers))
+                self.factory._ab_log("received HTTP status line in opening handshake : %s" % str(self.http_status_line))
+                self.factory._ab_log("received HTTP headers in opening handshake : %s" % str(self.http_headers))
 
             # Response Line
             #
@@ -4090,7 +4090,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
                 for (extension, params) in websocket_extensions:
 
                     if self.debug:
-                        self.factory._log("parsed WebSocket extension '%s' with params '%s'" % (extension, params))
+                        self.factory._ab_log("parsed WebSocket extension '%s' with params '%s'" % (extension, params))
 
                     # process permessage-compress extension
                     #
@@ -4160,7 +4160,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
             #
             if self.openHandshakeTimeoutCall is not None:
                 if self.debugCodePaths:
-                    self.factory._log("openHandshakeTimeoutCall.cancel")
+                    self.factory._ab_log("openHandshakeTimeoutCall.cancel")
                 self.openHandshakeTimeoutCall.cancel()
                 self.openHandshakeTimeoutCall = None
 
@@ -4205,7 +4205,7 @@ class WebSocketClientProtocol(WebSocketProtocol):
         connection.
         """
         if self.debug:
-            self.factory._log("failing WebSocket opening handshake ('%s')" % reason)
+            self.factory._ab_log("failing WebSocket opening handshake ('%s')" % reason)
         self.dropConnection(abort=True)
 
 


### PR DESCRIPTION
Twisted 15.3 adds a _log component on Protocols, and Autobahn overwrites this.