### PR TITLE
Replace skip skipTest in tests

### DIFF
--- a/autobahn/wamp/test/test_serializer.py
+++ b/autobahn/wamp/test/test_serializer.py
@@ -110,7 +110,7 @@ class TestSerializer(unittest.TestCase):
         """
 
         if not hasattr(serializer, 'MsgPackSerializer'):
-            self.skip("no msgpack")
+            self.skipTest("no msgpack")
 
         ser = serializer.MsgPackSerializer()
         payload = b'\x960\xce\x00\x01\xe2@\x80\xb4com.myapp.procedure1\x90\x82\xc4\x03str*\xa7unicode\x17'
@@ -128,7 +128,7 @@ class TestSerializer(unittest.TestCase):
         `use_bin_type=True`
         """
         if not hasattr(serializer, 'MsgPackSerializer'):
-            self.skip("no msgpack")
+            self.skipTest("no msgpack")
 
         ser = serializer.MsgPackSerializer(batched=True)
         payload = b'\x00\x00\x00-\x960\xce\x00\x01\xe2@\x80\xb4com.myapp.procedure1\x90\x82\xa7unicode\x17\xa3str*'


### PR DESCRIPTION
According the documentation of [unittest](), there is no skip method in
class TestCase. The intended behaviour must be achieved with
[skipTest](https://docs.python.org/2/library/unittest.html#unittest.TestCase.skipTest)