### PR TITLE
run examples

### DIFF
--- a/examples/run-all-examples.py
+++ b/examples/run-all-examples.py
@@ -55,16 +55,16 @@ class CrossbarProcessProtocol(ProcessProtocol):
 
     def outReceived(self, data):
         """ProcessProtocol override"""
-        self._out += data
+        self._out += data.decode('utf8')
         while '\n' in self._out:
             idx = self._out.find('\n')
             line = self._out[:idx]
-            self._out = self._out[idx+1:]
+            self._out = self._out[idx + 1:]
             sys.stdout.write(self.prefix + self.color + line + Fore.RESET + '\n')
 
     def errReceived(self, data):
         """ProcessProtocol override"""
-        self._err += data
+        self._err += data.decode('utf8')
         while '\n' in self._err:
             idx = self._err.find('\n')
             line = self._err[:idx]

--- a/examples/run-all-examples.py
+++ b/examples/run-all-examples.py
@@ -184,7 +184,9 @@ def main(reactor):
         py = sys.executable
         if exdir.startswith('py3 '):
             exdir = exdir[4:]
-            py = './venv-py3/bin/python'
+            if sys.version_info.major < 3:
+                print("don't have python3, skipping:", exdir)
+                continue
         frontend = join(exdir, 'frontend.py')
         backend = join(exdir, 'backend.py')
         if not exists(frontend) or not exists(backend):


### PR DESCRIPTION
Fixing #437; this checks if we have Python3 before trying to run any asyncio examples.