### PR TITLE
fix mock API use

### DIFF
--- a/autobahn/twisted/test/test_application_runner.py
+++ b/autobahn/twisted/test/test_application_runner.py
@@ -52,10 +52,8 @@ if os.environ.get('USE_TWISTED', False):
             self.assertRaises(RuntimeError, runner.run, raise_error)
 
             # both reactor.run and reactor.stop should have been called
-            run_calls = filter(lambda mc: mc.count('run'), fakereactor.method_calls)
-            stop_calls = filter(lambda mc: mc.count('stop'), fakereactor.method_calls)
-            self.assertEqual(len(run_calls), 1)
-            self.assertEqual(len(stop_calls), 1)
+            fakereactor.run.assert_called()
+            fakereactor.stop.assert_called()
 
         @patch('twisted.internet.reactor')
         @inlineCallbacks
@@ -73,10 +71,8 @@ if os.environ.get('USE_TWISTED', False):
 
             # neither reactor.run() NOR reactor.stop() should have been called
             # (just connectTCP() will have been called)
-            run_calls = filter(lambda mc: mc.count('run'), fakereactor.method_calls)
-            stop_calls = filter(lambda mc: mc.count('stop'), fakereactor.method_calls)
-            self.assertEqual(len(run_calls), 0)
-            self.assertEqual(len(stop_calls), 0)
+            fakereactor.run.assert_not_called()
+            fakereactor.stop.assert_not_called()
 
         @patch('twisted.internet.reactor')
         def test_runner_no_run_happypath(self, fakereactor):
@@ -94,10 +90,8 @@ if os.environ.get('USE_TWISTED', False):
 
             # neither reactor.run() NOR reactor.stop() should have been called
             # (just connectTCP() will have been called)
-            run_calls = filter(lambda mc: mc.count('run'), fakereactor.method_calls)
-            stop_calls = filter(lambda mc: mc.count('stop'), fakereactor.method_calls)
-            self.assertEqual(len(run_calls), 0)
-            self.assertEqual(len(stop_calls), 0)
+            fakereactor.run.assert_not_called()
+            fakereactor.stop.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This works with mock 1.0.1 or 1.3.0 now, using the supported
API. Fixes #436 