### PR TITLE
replace localhost with 127.0.0.1 in all examples

### DIFF
--- a/examples/asyncio/wamp/overview/backend.py
+++ b/examples/asyncio/wamp/overview/backend.py
@@ -21,7 +21,7 @@ class MyComponent(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/overview/frontend.py
+++ b/examples/asyncio/wamp/overview/frontend.py
@@ -18,7 +18,7 @@ class MyComponent(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/basic/backend.py
+++ b/examples/asyncio/wamp/pubsub/basic/backend.py
@@ -51,7 +51,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/basic/frontend.py
+++ b/examples/asyncio/wamp/pubsub/basic/frontend.py
@@ -59,7 +59,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/complex/backend.py
+++ b/examples/asyncio/wamp/pubsub/complex/backend.py
@@ -60,7 +60,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/complex/frontend.py
+++ b/examples/asyncio/wamp/pubsub/complex/frontend.py
@@ -64,7 +64,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/decorators/backend.py
+++ b/examples/asyncio/wamp/pubsub/decorators/backend.py
@@ -55,7 +55,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/decorators/frontend.py
+++ b/examples/asyncio/wamp/pubsub/decorators/frontend.py
@@ -74,7 +74,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/options/backend.py
+++ b/examples/asyncio/wamp/pubsub/options/backend.py
@@ -61,7 +61,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/options/frontend.py
+++ b/examples/asyncio/wamp/pubsub/options/frontend.py
@@ -61,7 +61,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/pubsub/tls/backend_selfsigned.py
+++ b/examples/asyncio/wamp/pubsub/tls/backend_selfsigned.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     options = ssl.create_default_context(cadata=open(cert_path, 'r').read())
     # ...which we pass as "ssl=" to ApplicationRunner (passed to loop.create_connection)
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "wss://localhost:8083/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "wss://127.0.0.1:8083/ws"),
         u"crossbardemo",
         ssl=options,  # try removing this, but still use self-signed cert
         debug_wamp=False,  # optional; log many WAMP details

--- a/examples/asyncio/wamp/pubsub/unsubscribe/frontend.py
+++ b/examples/asyncio/wamp/pubsub/unsubscribe/frontend.py
@@ -76,7 +76,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/arguments/backend.py
+++ b/examples/asyncio/wamp/rpc/arguments/backend.py
@@ -69,7 +69,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/arguments/frontend.py
+++ b/examples/asyncio/wamp/rpc/arguments/frontend.py
@@ -86,7 +86,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/complex/backend.py
+++ b/examples/asyncio/wamp/rpc/complex/backend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/complex/frontend.py
+++ b/examples/asyncio/wamp/rpc/complex/frontend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/decorators/backend.py
+++ b/examples/asyncio/wamp/rpc/decorators/backend.py
@@ -75,7 +75,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/decorators/frontend.py
+++ b/examples/asyncio/wamp/rpc/decorators/frontend.py
@@ -61,7 +61,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/errors/backend.py
+++ b/examples/asyncio/wamp/rpc/errors/backend.py
@@ -94,7 +94,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/errors/frontend.py
+++ b/examples/asyncio/wamp/rpc/errors/frontend.py
@@ -91,7 +91,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/options/backend.py
+++ b/examples/asyncio/wamp/rpc/options/backend.py
@@ -62,7 +62,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/options/frontend.py
+++ b/examples/asyncio/wamp/rpc/options/frontend.py
@@ -60,7 +60,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/progress/backend.py
+++ b/examples/asyncio/wamp/rpc/progress/backend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/progress/frontend.py
+++ b/examples/asyncio/wamp/rpc/progress/frontend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/slowsquare/backend.py
+++ b/examples/asyncio/wamp/rpc/slowsquare/backend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/slowsquare/frontend.py
+++ b/examples/asyncio/wamp/rpc/slowsquare/frontend.py
@@ -69,7 +69,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/timeservice/backend.py
+++ b/examples/asyncio/wamp/rpc/timeservice/backend.py
@@ -53,7 +53,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/wamp/rpc/timeservice/frontend.py
+++ b/examples/asyncio/wamp/rpc/timeservice/frontend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/asyncio/websocket/echo/client.py
+++ b/examples/asyncio/websocket/echo/client.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/echo/client_coroutines.py
+++ b/examples/asyncio/websocket/echo/client_coroutines.py
@@ -60,7 +60,7 @@ class MyClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/echo/client_coroutines_py2.py
+++ b/examples/asyncio/websocket/echo/client_coroutines_py2.py
@@ -57,7 +57,7 @@ class MyClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyClientProtocol
 
     loop = trollius.get_event_loop()

--- a/examples/asyncio/websocket/echo/server.py
+++ b/examples/asyncio/websocket/echo/server.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyServerProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/client.py
+++ b/examples/asyncio/websocket/slowsquare/client.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = SlowSquareClientProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/server.py
+++ b/examples/asyncio/websocket/slowsquare/server.py
@@ -58,7 +58,7 @@ class SlowSquareServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = SlowSquareServerProtocol
 
     loop = asyncio.get_event_loop()

--- a/examples/asyncio/websocket/slowsquare/server_py2.py
+++ b/examples/asyncio/websocket/slowsquare/server_py2.py
@@ -55,7 +55,7 @@ class SlowSquareServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = SlowSquareServerProtocol
 
     loop = trollius.get_event_loop()

--- a/examples/asyncio/websocket/testee/testee_server.py
+++ b/examples/asyncio/websocket/testee/testee_server.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
         # Trollius >= 0.3 was renamed
         import trollius as asyncio
 
-    factory = TesteeServerFactory("ws://localhost:9002", debug=False)
+    factory = TesteeServerFactory("ws://127.0.0.1:9002", debug=False)
 
     loop = asyncio.get_event_loop()
     coro = loop.create_server(factory, port=9002)

--- a/examples/twisted/wamp/app/calculator/calculator.py
+++ b/examples/twisted/wamp/app/calculator/calculator.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     from autobahn.twisted.wamp import ApplicationRunner
 
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/app/crochet/example2/server.py
+++ b/examples/twisted/wamp/app/crochet/example2/server.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     #
     @run_in_reactor
     def start_wamp():
-        wapp.run("ws://localhost:9000", "realm1", standalone=True, start_reactor=False)
+        wapp.run("ws://127.0.0.1:9000", "realm1", standalone=True, start_reactor=False)
 
     start_wamp()
 

--- a/examples/twisted/wamp/app/dbus/bridge.py
+++ b/examples/twisted/wamp/app/dbus/bridge.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     # run WAMP application component
     ##
     from autobahn.twisted.wamp import ApplicationRunner
-    router = args.router or 'ws://localhost:9000'
+    router = args.router or 'ws://127.0.0.1:9000'
 
     runner = ApplicationRunner(router, u"realm1", standalone=not args.router,
                                debug=False,             # low-level logging

--- a/examples/twisted/wamp/app/hello/hello.py
+++ b/examples/twisted/wamp/app/hello/hello.py
@@ -50,4 +50,4 @@ def onjoined():
 
 
 if __name__ == "__main__":
-    app.run("ws://localhost:8080/ws", "realm1", standalone=True)
+    app.run("ws://127.0.0.1:8080/ws", "realm1", standalone=True)

--- a/examples/twisted/wamp/app/keyvalue/store.py
+++ b/examples/twisted/wamp/app/keyvalue/store.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
     # run WAMP application component
     ##
     from autobahn.twisted.wamp import ApplicationRunner
-    router = args.router or 'ws://localhost:9000'
+    router = args.router or 'ws://127.0.0.1:9000'
 
     runner = ApplicationRunner(router, u"realm1", standalone=not args.router,
                                debug=False,             # low-level logging

--- a/examples/twisted/wamp/app/klein/example1/server_wamp.py
+++ b/examples/twisted/wamp/app/klein/example1/server_wamp.py
@@ -36,4 +36,4 @@ def square(x):
 
 
 if __name__ == "__main__":
-    app.run("ws://localhost:9000", "realm1", standalone=True)
+    app.run("ws://127.0.0.1:9000", "realm1", standalone=True)

--- a/examples/twisted/wamp/app/klein/example1/server_web.py
+++ b/examples/twisted/wamp/app/klein/example1/server_web.py
@@ -48,4 +48,4 @@ if __name__ == "__main__":
     log.startLogging(sys.stdout)
 
     reactor.listenTCP(8080, Site(app.resource()))
-    wampapp.run("ws://localhost:9000", "realm1", standalone=False)
+    wampapp.run("ws://127.0.0.1:9000", "realm1", standalone=False)

--- a/examples/twisted/wamp/app/klein/example2/server.py
+++ b/examples/twisted/wamp/app/klein/example2/server.py
@@ -80,4 +80,4 @@ if __name__ == "__main__":
     log.startLogging(sys.stdout)
 
     reactor.listenTCP(8080, Site(webapp.resource()))
-    wampapp.run("ws://localhost:9000", "realm1", standalone=True)
+    wampapp.run("ws://127.0.0.1:9000", "realm1", standalone=True)

--- a/examples/twisted/wamp/app/serial2ws/serial2ws.py
+++ b/examples/twisted/wamp/app/serial2ws/serial2ws.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
     # run WAMP application component
     ##
     from autobahn.twisted.wamp import ApplicationRunner
-    router = args.router or 'ws://localhost:8080'
+    router = args.router or 'ws://127.0.0.1:8080'
 
     runner = ApplicationRunner(router, u"realm1",
                                extra={'port': args.port, 'baudrate': args.baudrate, 'debug': args.debug},

--- a/examples/twisted/wamp/app/subscribe_upon_call/subscribe_upon_call.py
+++ b/examples/twisted/wamp/app/subscribe_upon_call/subscribe_upon_call.py
@@ -46,4 +46,4 @@ def onjoined():
 
 
 if __name__ == "__main__":
-    app.run("ws://localhost:8080/ws", "realm1", standalone=True)
+    app.run("ws://127.0.0.1:8080/ws", "realm1", standalone=True)

--- a/examples/twisted/wamp/overview/backend.py
+++ b/examples/twisted/wamp/overview/backend.py
@@ -23,7 +23,7 @@ class MyComponent(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/overview/frontend.py
+++ b/examples/twisted/wamp/overview/frontend.py
@@ -19,7 +19,7 @@ class MyComponent(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/basic/backend.py
+++ b/examples/twisted/wamp/pubsub/basic/backend.py
@@ -51,7 +51,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/basic/frontend.py
+++ b/examples/twisted/wamp/pubsub/basic/frontend.py
@@ -62,7 +62,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         extra=dict(
             max_events=5,  # [A] pass in additional configuration

--- a/examples/twisted/wamp/pubsub/complex/backend.py
+++ b/examples/twisted/wamp/pubsub/complex/backend.py
@@ -61,7 +61,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/complex/frontend.py
+++ b/examples/twisted/wamp/pubsub/complex/frontend.py
@@ -68,7 +68,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/decorators/backend.py
+++ b/examples/twisted/wamp/pubsub/decorators/backend.py
@@ -56,7 +56,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/decorators/frontend.py
+++ b/examples/twisted/wamp/pubsub/decorators/frontend.py
@@ -70,7 +70,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/options/backend.py
+++ b/examples/twisted/wamp/pubsub/options/backend.py
@@ -67,7 +67,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/options/frontend.py
+++ b/examples/twisted/wamp/pubsub/options/frontend.py
@@ -64,7 +64,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/unsubscribe/backend.py
+++ b/examples/twisted/wamp/pubsub/unsubscribe/backend.py
@@ -52,7 +52,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/pubsub/unsubscribe/frontend.py
+++ b/examples/twisted/wamp/pubsub/unsubscribe/frontend.py
@@ -72,7 +72,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/arguments/backend.py
+++ b/examples/twisted/wamp/rpc/arguments/backend.py
@@ -65,7 +65,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/arguments/frontend.py
+++ b/examples/twisted/wamp/rpc/arguments/frontend.py
@@ -85,7 +85,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/complex/backend.py
+++ b/examples/twisted/wamp/rpc/complex/backend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/complex/frontend.py
+++ b/examples/twisted/wamp/rpc/complex/frontend.py
@@ -56,7 +56,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/decorators/backend.py
+++ b/examples/twisted/wamp/rpc/decorators/backend.py
@@ -88,7 +88,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/decorators/frontend.py
+++ b/examples/twisted/wamp/rpc/decorators/frontend.py
@@ -61,7 +61,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/errors/backend.py
+++ b/examples/twisted/wamp/rpc/errors/backend.py
@@ -93,7 +93,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/errors/frontend.py
+++ b/examples/twisted/wamp/rpc/errors/frontend.py
@@ -91,7 +91,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/options/backend.py
+++ b/examples/twisted/wamp/rpc/options/backend.py
@@ -62,7 +62,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/options/frontend.py
+++ b/examples/twisted/wamp/rpc/options/frontend.py
@@ -59,7 +59,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/progress/backend.py
+++ b/examples/twisted/wamp/rpc/progress/backend.py
@@ -60,7 +60,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/progress/frontend.py
+++ b/examples/twisted/wamp/rpc/progress/frontend.py
@@ -57,7 +57,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/slowsquare/backend.py
+++ b/examples/twisted/wamp/rpc/slowsquare/backend.py
@@ -58,7 +58,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/slowsquare/frontend.py
+++ b/examples/twisted/wamp/rpc/slowsquare/frontend.py
@@ -66,7 +66,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/timeservice/backend.py
+++ b/examples/twisted/wamp/rpc/timeservice/backend.py
@@ -55,7 +55,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/rpc/timeservice/frontend.py
+++ b/examples/twisted/wamp/rpc/timeservice/frontend.py
@@ -55,7 +55,7 @@ class Component(ApplicationSession):
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        environ.get("AUTOBAHN_DEMO_ROUTER", "ws://127.0.0.1:8080/ws"),
         u"crossbardemo",
         debug_wamp=False,  # optional; log many WAMP details
         debug=False,  # optional; log even more details

--- a/examples/twisted/wamp/wamplet/wampirc/wampirc/service.py
+++ b/examples/twisted/wamp/wamplet/wampirc/wampirc/service.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
 
     # test drive the component during development ..
     runner = ApplicationRunner(
-        url="ws://localhost:8080/ws",
+        url="ws://127.0.0.1:8080/ws",
         realm="realm1",
         extra=extra,
         debug=False,  # low-level WebSocket debugging

--- a/examples/twisted/websocket/auth_persona/server.py
+++ b/examples/twisted/websocket/auth_persona/server.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
     print("Running Autobahn|Python {}".format(autobahn.version))
 
     # our WebSocket server factory
-    factory = PersonaServerFactory("ws://localhost:8080")
+    factory = PersonaServerFactory("ws://127.0.0.1:8080")
 
     # we serve static files under "/" ..
     root = File(".")

--- a/examples/twisted/websocket/broadcast/client.py
+++ b/examples/twisted/websocket/broadcast/client.py
@@ -53,7 +53,7 @@ class BroadcastClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     factory = WebSocketClientFactory(sys.argv[1])

--- a/examples/twisted/websocket/broadcast/server.py
+++ b/examples/twisted/websocket/broadcast/server.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
     ServerFactory = BroadcastServerFactory
     # ServerFactory = BroadcastPreparedServerFactory
 
-    factory = ServerFactory("ws://localhost:9000",
+    factory = ServerFactory("ws://127.0.0.1:9000",
                             debug=debug,
                             debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo/client.py
+++ b/examples/twisted/websocket/echo/client.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/echo/client_coroutines.py
+++ b/examples/twisted/websocket/echo/client_coroutines.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/echo/server.py
+++ b/examples/twisted/websocket/echo/server.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyServerProtocol
     # factory.setProtocolOptions(maxConnections=2)
 

--- a/examples/twisted/websocket/echo_compressed/client.py
+++ b/examples/twisted/websocket/echo_compressed/client.py
@@ -59,7 +59,7 @@ class EchoClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     if len(sys.argv) > 2 and sys.argv[2] == 'debug':

--- a/examples/twisted/websocket/echo_compressed/client_advanced.py
+++ b/examples/twisted/websocket/echo_compressed/client_advanced.py
@@ -56,7 +56,7 @@ class EchoClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print "Need the WebSocket server address, i.e. ws://localhost:9000"
+        print "Need the WebSocket server address, i.e. ws://127.0.0.1:9000"
         sys.exit(1)
 
     if len(sys.argv) > 2 and sys.argv[2] == 'debug':

--- a/examples/twisted/websocket/echo_compressed/server.py
+++ b/examples/twisted/websocket/echo_compressed/server.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     else:
         debug = False
 
-    factory = WebSocketServerFactory("ws://localhost:9000",
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_compressed/server_advanced.py
+++ b/examples/twisted/websocket/echo_compressed/server_advanced.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     else:
         debug = False
 
-    factory = WebSocketServerFactory("ws://localhost:9000",
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_endpoints/client.py
+++ b/examples/twisted/websocket/echo_endpoints/client.py
@@ -72,11 +72,11 @@ if __name__ == '__main__':
     parser.add_argument("-d", "--debug", action="store_true",
                         help="Enable debug output.")
 
-    parser.add_argument("--websocket", default="tcp:localhost:9000",
-                        help='WebSocket client Twisted endpoint descriptor, e.g. "tcp:localhost:9000" or "unix:/tmp/mywebsocket".')
+    parser.add_argument("--websocket", default="tcp:127.0.0.1:9000",
+                        help='WebSocket client Twisted endpoint descriptor, e.g. "tcp:127.0.0.1:9000" or "unix:/tmp/mywebsocket".')
 
-    parser.add_argument("--wsurl", default="ws://localhost:9000",
-                        help='WebSocket URL (must suit the endpoint), e.g. "ws://localhost:9000".')
+    parser.add_argument("--wsurl", default="ws://127.0.0.1:9000",
+                        help='WebSocket URL (must suit the endpoint), e.g. "ws://127.0.0.1:9000".')
 
     args = parser.parse_args()
 

--- a/examples/twisted/websocket/echo_endpoints/server.py
+++ b/examples/twisted/websocket/echo_endpoints/server.py
@@ -70,8 +70,8 @@ if __name__ == '__main__':
     parser.add_argument("--websocket", default="tcp:9000",
                         help='WebSocket server Twisted endpoint descriptor, e.g. "tcp:9000" or "unix:/tmp/mywebsocket".')
 
-    parser.add_argument("--wsurl", default="ws://localhost:9000",
-                        help='WebSocket URL (must suit the endpoint), e.g. "ws://localhost:9000".')
+    parser.add_argument("--wsurl", default="ws://127.0.0.1:9000",
+                        help='WebSocket URL (must suit the endpoint), e.g. "ws://127.0.0.1:9000".')
 
     parser.add_argument("--web", default="tcp:8080",
                         help='Web server endpoint descriptor, e.g. "tcp:8080".')

--- a/examples/twisted/websocket/echo_httpheaders/client.py
+++ b/examples/twisted/websocket/echo_httpheaders/client.py
@@ -54,7 +54,7 @@ class EchoClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     if len(sys.argv) > 2 and sys.argv[2] == 'debug':

--- a/examples/twisted/websocket/echo_httpheaders/server.py
+++ b/examples/twisted/websocket/echo_httpheaders/server.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
 
     headers = {'MyCustomServerHeader': 'Foobar'}
 
-    factory = WebSocketServerFactory("ws://localhost:9000",
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000",
                                      headers=headers,
                                      debug=debug,
                                      debugCodePaths=debug)

--- a/examples/twisted/websocket/echo_multicore/server.py
+++ b/examples/twisted/websocket/echo_multicore/server.py
@@ -355,7 +355,7 @@ if __name__ == '__main__':
     DEFAULT_WORKERS = psutil.NUM_CPUS
 
     parser = argparse.ArgumentParser(description='Autobahn WebSocket Echo Multicore Server')
-    parser.add_argument('--wsuri', dest='wsuri', type=str, default='ws://localhost:9000', help='The WebSocket URI the server is listening on, e.g. ws://localhost:9000.')
+    parser.add_argument('--wsuri', dest='wsuri', type=str, default='ws://127.0.0.1:9000', help='The WebSocket URI the server is listening on, e.g. ws://localhost:9000.')
     parser.add_argument('--port', dest='port', type=int, default=8080, help='Port to listen on for embedded Web server. Set to 0 to disable.')
     parser.add_argument('--workers', dest='workers', type=int, default=DEFAULT_WORKERS, help='Number of workers to spawn - should fit the number of (physical) CPU cores.')
     parser.add_argument('--noaffinity', dest='noaffinity', action="store_true", default=False, help='Do not set worker/CPU affinity.')

--- a/examples/twisted/websocket/echo_service/echows/echoservice.py
+++ b/examples/twisted/websocket/echo_service/echows/echoservice.py
@@ -60,7 +60,7 @@ class EchoService(service.Service):
 
     def startService(self):
 
-        factory = WebSocketServerFactory("ws://localhost:%d" % self.port, debug=self.debug)
+        factory = WebSocketServerFactory("ws://127.0.0.1:%d" % self.port, debug=self.debug)
 
         factory.protocol = EchoServerProtocol
         factory.setProtocolOptions(allowHixie76=True)  # needed if Hixie76 is to be supported

--- a/examples/twisted/websocket/echo_site/server.py
+++ b/examples/twisted/websocket/echo_site/server.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     else:
         debug = False
 
-    factory = WebSocketServerFactory("ws://localhost:8080",
+    factory = WebSocketServerFactory("ws://127.0.0.1:8080",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_site_tls/server.py
+++ b/examples/twisted/websocket/echo_site_tls/server.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     contextFactory = ssl.DefaultOpenSSLContextFactory('keys/server.key',
                                                       'keys/server.crt')
 
-    factory = WebSocketServerFactory("wss://localhost:8080",
+    factory = WebSocketServerFactory("wss://127.0.0.1:8080",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_tls/client.py
+++ b/examples/twisted/websocket/echo_tls/client.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
     log.startLogging(sys.stdout)
 
     parser = OptionParser()
-    parser.add_option("-u", "--url", dest="url", help="The WebSocket URL", default="wss://localhost:9000")
+    parser.add_option("-u", "--url", dest="url", help="The WebSocket URL", default="wss://127.0.0.1:9000")
     (options, args) = parser.parse_args()
 
     # create a WS server factory with our protocol

--- a/examples/twisted/websocket/echo_tls/server.py
+++ b/examples/twisted/websocket/echo_tls/server.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     contextFactory = ssl.DefaultOpenSSLContextFactory('keys/server.key',
                                                       'keys/server.crt')
 
-    factory = WebSocketServerFactory("wss://localhost:9000",
+    factory = WebSocketServerFactory("wss://127.0.0.1:9000",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_variants/client.py
+++ b/examples/twisted/websocket/echo_variants/client.py
@@ -51,7 +51,7 @@ class EchoClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     if len(sys.argv) > 2 and sys.argv[2] == 'debug':

--- a/examples/twisted/websocket/echo_variants/client_reconnecting.py
+++ b/examples/twisted/websocket/echo_variants/client_reconnecting.py
@@ -73,7 +73,7 @@ class EchoClientFactory(ReconnectingClientFactory, WebSocketClientFactory):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     if len(sys.argv) > 2 and sys.argv[2] == 'debug':

--- a/examples/twisted/websocket/echo_variants/client_with_params.py
+++ b/examples/twisted/websocket/echo_variants/client_with_params.py
@@ -59,7 +59,7 @@ class EchoClientFactory(WebSocketClientFactory):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print "Need the WebSocket server address, i.e. ws://localhost:9000"
+        print "Need the WebSocket server address, i.e. ws://127.0.0.1:9000"
         sys.exit(1)
 
     factory = EchoClientFactory(sys.argv[1])

--- a/examples/twisted/websocket/echo_variants/client_with_proxy.py
+++ b/examples/twisted/websocket/echo_variants/client_with_proxy.py
@@ -51,7 +51,7 @@ class EchoClientProtocol(WebSocketClientProtocol):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     if len(sys.argv) < 3:

--- a/examples/twisted/websocket/echo_variants/server.py
+++ b/examples/twisted/websocket/echo_variants/server.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     else:
         debug = False
 
-    factory = WebSocketServerFactory("ws://localhost:9000",
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000",
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_wsfallbacks/server.py
+++ b/examples/twisted/websocket/echo_wsfallbacks/server.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
 
     # Our WebSocket server
     ##
-    factory = WebSocketServerFactory("ws://localhost:%d" % wsPort,
+    factory = WebSocketServerFactory("ws://127.0.0.1:%d" % wsPort,
                                      debug=debug,
                                      debugCodePaths=debug)
 

--- a/examples/twisted/websocket/echo_wsgi/server.py
+++ b/examples/twisted/websocket/echo_wsgi/server.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     ##
     # create a Twisted Web resource for our WebSocket server
     ##
-    wsFactory = WebSocketServerFactory("ws://localhost:8080",
+    wsFactory = WebSocketServerFactory("ws://127.0.0.1:8080",
                                        debug=debug,
                                        debugCodePaths=debug)
 

--- a/examples/twisted/websocket/multiproto/client.py
+++ b/examples/twisted/websocket/multiproto/client.py
@@ -67,7 +67,7 @@ class EchoClientFactory(WebSocketClientFactory):
 if __name__ == '__main__':
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000/echo1")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000/echo1")
         sys.exit(1)
 
     factory = EchoClientFactory(sys.argv[1])

--- a/examples/twisted/websocket/multiproto/server1.py
+++ b/examples/twisted/websocket/multiproto/server1.py
@@ -132,7 +132,7 @@ class ServiceServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory("ws://localhost:9000")
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000")
     factory.protocol = ServiceServerProtocol
     listenWS(factory)
 

--- a/examples/twisted/websocket/ping/client.py
+++ b/examples/twisted/websocket/ping/client.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     log.startLogging(sys.stdout)
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     factory = WebSocketClientFactory(sys.argv[1], debug='debug' in sys.argv)

--- a/examples/twisted/websocket/ping/server.py
+++ b/examples/twisted/websocket/ping/server.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     contextFactory = ssl.DefaultOpenSSLContextFactory('keys/server.key',
                                                       'keys/server.crt')
 
-    factory = PingServerFactory("wss://localhost:9000",
+    factory = PingServerFactory("wss://127.0.0.1:9000",
                                 debug='debug' in sys.argv)
 
     factory.protocol = PingServerProtocol

--- a/examples/twisted/websocket/pingpong_keepalive/client.py
+++ b/examples/twisted/websocket/pingpong_keepalive/client.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     log.startLogging(sys.stdout)
 
     if len(sys.argv) < 2:
-        print("Need the WebSocket server address, i.e. ws://localhost:9000")
+        print("Need the WebSocket server address, i.e. ws://127.0.0.1:9000")
         sys.exit(1)
 
     factory = WebSocketClientFactory(sys.argv[1], debug=True)

--- a/examples/twisted/websocket/pingpong_keepalive/server.py
+++ b/examples/twisted/websocket/pingpong_keepalive/server.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False, debugCodePaths=True)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False, debugCodePaths=True)
     factory.protocol = WebSocketServerProtocol
 
     factory.setProtocolOptions(autoPingInterval=1, autoPingTimeout=3, autoPingSize=20)

--- a/examples/twisted/websocket/reconnecting/client.py
+++ b/examples/twisted/websocket/reconnecting/client.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = MyClientFactory("ws://localhost:9000", debug=False)
+    factory = MyClientFactory("ws://127.0.0.1:9000", debug=False)
 
     reactor.connectTCP("127.0.0.1", 9000, factory)
     reactor.run()

--- a/examples/twisted/websocket/reconnecting/server.py
+++ b/examples/twisted/websocket/reconnecting/server.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = MyServerProtocol
 
     reactor.listenTCP(9000, factory)

--- a/examples/twisted/websocket/slowsquare/client.py
+++ b/examples/twisted/websocket/slowsquare/client.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketClientFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = SlowSquareClientProtocol
 
     reactor.connectTCP("127.0.0.1", 9000, factory)

--- a/examples/twisted/websocket/slowsquare/server.py
+++ b/examples/twisted/websocket/slowsquare/server.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = WebSocketServerFactory("ws://localhost:9000", debug=False)
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000", debug=False)
     factory.protocol = SlowSquareServerProtocol
 
     reactor.listenTCP(9000, factory)

--- a/examples/twisted/websocket/streaming/frame_based_client.py
+++ b/examples/twisted/websocket/streaming/frame_based_client.py
@@ -84,7 +84,7 @@ class FrameBasedHashClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000")
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000")
     factory.protocol = FrameBasedHashClientProtocol
 
     enableCompression = False

--- a/examples/twisted/websocket/streaming/frame_based_server.py
+++ b/examples/twisted/websocket/streaming/frame_based_server.py
@@ -60,7 +60,7 @@ class FrameBasedHashServerProtocol(WebSocketServerProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketServerFactory("ws://localhost:9000")
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000")
     factory.protocol = FrameBasedHashServerProtocol
 
     enableCompression = False

--- a/examples/twisted/websocket/streaming/message_based_client.py
+++ b/examples/twisted/websocket/streaming/message_based_client.py
@@ -59,7 +59,7 @@ class MessageBasedHashClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000")
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000")
     factory.protocol = MessageBasedHashClientProtocol
     connectWS(factory)
     reactor.run()

--- a/examples/twisted/websocket/streaming/message_based_server.py
+++ b/examples/twisted/websocket/streaming/message_based_server.py
@@ -48,7 +48,7 @@ class MessageBasedHashServerProtocol(WebSocketServerProtocol):
 
 
 if __name__ == '__main__':
-    factory = WebSocketServerFactory("ws://localhost:9000")
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000")
     factory.protocol = MessageBasedHashServerProtocol
     listenWS(factory)
     reactor.run()

--- a/examples/twisted/websocket/streaming/streaming_client.py
+++ b/examples/twisted/websocket/streaming/streaming_client.py
@@ -67,7 +67,7 @@ class StreamingHashClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000")
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000")
     factory.protocol = StreamingHashClientProtocol
     connectWS(factory)
     reactor.run()

--- a/examples/twisted/websocket/streaming/streaming_producer_client.py
+++ b/examples/twisted/websocket/streaming/streaming_producer_client.py
@@ -95,7 +95,7 @@ class StreamingProducerHashClientProtocol(WebSocketClientProtocol):
 
 if __name__ == '__main__':
 
-    factory = WebSocketClientFactory("ws://localhost:9000")
+    factory = WebSocketClientFactory("ws://127.0.0.1:9000")
     factory.protocol = StreamingProducerHashClientProtocol
     connectWS(factory)
     reactor.run()

--- a/examples/twisted/websocket/streaming/streaming_server.py
+++ b/examples/twisted/websocket/streaming/streaming_server.py
@@ -89,7 +89,7 @@ class StreamingHashServerProtocol(WebSocketServerProtocol):
 
 
 if __name__ == '__main__':
-    factory = WebSocketServerFactory("ws://localhost:9000")
+    factory = WebSocketServerFactory("ws://127.0.0.1:9000")
     factory.protocol = StreamingHashServerProtocol
     listenWS(factory)
     reactor.run()

--- a/examples/twisted/websocket/testee/testee_server.py
+++ b/examples/twisted/websocket/testee/testee_server.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = TesteeServerFactory("ws://localhost:9001", debug=False)
+    factory = TesteeServerFactory("ws://127.0.0.1:9001", debug=False)
 
     reactor.listenTCP(9001, factory)
     reactor.run()

--- a/examples/twisted/websocket/wrapping/client.py
+++ b/examples/twisted/websocket/wrapping/client.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     wrappedFactory = Factory.forProtocol(HelloClientProtocol)
     factory = WrappingWebSocketClientFactory(wrappedFactory,
-                                             "ws://localhost:9000",
+                                             "ws://127.0.0.1:9000",
                                              debug=False,
                                              enableCompression=False,
                                              autoFragmentSize=1024)

--- a/examples/twisted/websocket/wrapping/client_endpoint.py
+++ b/examples/twisted/websocket/wrapping/client_endpoint.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
 
     wrappedFactory = Factory.forProtocol(HelloClientProtocol)
 
-    endpoint = clientFromString(reactor, "autobahn:tcp\:localhost\:9000:url=ws\://localhost\:9000")
+    endpoint = clientFromString(reactor, "autobahn:tcp\:127.0.0.1\:9000:url=ws\://localhost\:9000")
     endpoint.connect(wrappedFactory)
 
     reactor.run()

--- a/examples/twisted/websocket/wrapping/server.py
+++ b/examples/twisted/websocket/wrapping/server.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     wrappedFactory = Factory.forProtocol(HelloServerProtocol)
     factory = WrappingWebSocketServerFactory(wrappedFactory,
-                                             "ws://localhost:9000",
+                                             "ws://127.0.0.1:9000",
                                              debug=False,
                                              enableCompression=False,
                                              autoFragmentSize=1024)

--- a/examples/twisted/websocket/wrapping/server_endpoint.py
+++ b/examples/twisted/websocket/wrapping/server_endpoint.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
 
     wrappedFactory = Factory.forProtocol(HelloServerProtocol)
 
-    endpoint = serverFromString(reactor, "autobahn:tcp\:9000:url=ws\://localhost\:9000")
+    endpoint = serverFromString(reactor, "autobahn:tcp\:9000:url=ws\://127.0.0.1\:9000")
     endpoint.listen(wrappedFactory)
 
     reactor.run()

--- a/examples/twisted/websocket/wxpython/client.py
+++ b/examples/twisted/websocket/wxpython/client.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
     app._frame.Show()
     reactor.registerWxApp(app)
 
-    app._factory = MyClientFactory("ws://localhost:9000", app)
+    app._factory = MyClientFactory("ws://127.0.0.1:9000", app)
 
     reactor.connectTCP("127.0.0.1", 9000, app._factory)
 

--- a/examples/twisted/websocket/wxpython/server.py
+++ b/examples/twisted/websocket/wxpython/server.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
 
     log.startLogging(sys.stdout)
 
-    factory = BroadcastServerFactory("ws://localhost:9000")
+    factory = BroadcastServerFactory("ws://127.0.0.1:9000")
 
     reactor.listenTCP(9000, factory)
     reactor.run()


### PR DESCRIPTION
This ensures we use IPv4 addresses; at least with Trollius
on Python 2.7 "localhost" can result in IPv6 addresses but
the examples are all currently written for IPv4