### PR TITLE
default implementation for onConnect/onChallenge

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -45,6 +45,7 @@ from autobahn.wamp import uri
 from autobahn.wamp import message
 from autobahn.wamp import types
 from autobahn.wamp import role
+from autobahn.wamp import auth
 from autobahn.wamp import exception
 from autobahn.wamp.exception import ApplicationError, ProtocolError, SessionNotReady, SerializationError
 from autobahn.wamp.types import SessionDetails
@@ -468,8 +469,26 @@ class ApplicationSession(BaseSession):
     def onConnect(self):
         """
         Implements :func:`autobahn.wamp.interfaces.ISession.onConnect`
+
+        This provides a default implementation that will call
+        ``.join`` to the realm in ``self.config.realm``.
+
+        Additionally, if ``self.config.extra`` is a dict with a valid
+        ``wamp_cra`` key in it (see
+        :meth:`autobahn.wamp.protocol.ApplicationSession.onChallenge`)
+        the ``join()`` will include ``authmethods=[u'wampcra']`` and
+        ``authid=`` kwargs.
         """
-        self.join(self.config.realm)
+        authuser = None
+        authmethods = []
+        if isinstance(self.config.extra, dict) and 'wamp_cra' in self.config.extra:
+            try:
+                authuser = self.config.extra['wamp_cra']['user']
+            except KeyError:
+                raise Exception("extra['wamp_cra'] requires 'user'")
+            authmethods.append(u'wampcra')
+
+        self.join(self.config.realm, authmethods=authmethods, authid=authuser)
 
     def join(self, realm, authmethods=None, authid=None):
         """
@@ -954,8 +973,40 @@ class ApplicationSession(BaseSession):
     def onChallenge(self, challenge):
         """
         Implements :func:`autobahn.wamp.interfaces.ISession.onChallenge`
+
+        This provides a default implementation which will respond
+        appropriately for WAMP-CRA authentication if your
+        ``self.config.extra`` is a ``dict`` and contains a
+        ``wamp_cra`` key. This in turn is a dict with two keys:
+        ``user`` for the authid and ``secret`` (this will go through
+        salting/hashing if the server provides those details in the
+        challenge).
         """
-        raise Exception("received authentication challenge, but onChallenge not implemented")
+        if not isinstance(self.config.extra, dict):
+            raise Exception("override onChallenge to do authentication")
+
+        wamp_cra = self.config.extra.get('wamp_cra', None)
+        if not wamp_cra:
+            raise Exception("override onChallenge or provide 'wamp_cra'"
+                            " config in 'extra'")
+
+        if not isinstance(wamp_cra, dict):
+            raise Exception("extra['wamp_cra'] should be a dict")
+        if 'secret' not in wamp_cra:
+            raise Exception("wamp_cra needs 'secret' key")
+
+        if 'salt' in challenge.extra:
+            key = auth.derive_key(
+                wamp_cra['secret'],
+                challenge.extra['salt'].encode('utf8'),
+                iterations=challenge.extra['iterations'],
+                keylen=challenge.extra['keylen'],
+            )
+        else:
+            key = wamp_cra['secret']
+
+        signature = auth.compute_wcs(key, challenge.extra['challenge'])
+        return signature.decode('ascii')
 
     def onJoin(self, details):
         """


### PR DESCRIPTION
While looking at https://github.com/crossbario/crossbar/issues/412 there's a lot of ``onChallenge`` code to get right in order for authenticated login to work.

This adds a default ``onChallenge`` (and extends the default ``onConnect``) method to make authentication much easier: you simply add a 'wamp_cra' section to your ``ApplicationSession``'s ``config.extra``, which itself is a dict containing 'secret' and 'user'. Like:

```
extra = {
    'wamp_cra': {
        'user': 'meejah',
        'secret': 'cr0ssb4r',
    }
    # whatever else your app uses
}
ApplicationSession(..., extra=extra)
```

If ``extra`` is not a dict, or doesn't have ``wamp_cra`` in it, ``onConnect`` works as before (i.e. you have to write your own, and your own ``onChallenge``).