### PR TITLE
Transport configuration checking code

### DIFF
--- a/autobahn/asyncio/connection.py
+++ b/autobahn/asyncio/connection.py
@@ -1,0 +1,48 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+
+from __future__ import absolute_import, print_function
+
+import ssl
+
+
+def _check_asyncio_endpoint(endpoint):
+    if type(endpoint) != dict:
+        raise Exception("'endpoint' must be a dict")
+
+    kind = endpoint.get('type', 'tcp')
+    if kind == 'tcp':
+        tls = endpoint.get('tls', None)
+        if tls:
+            acceptable = False
+            if tls in [True, False]:
+                acceptable = True
+            elif isinstance(tls, ssl.SSLContext):
+                acceptable = True
+            if not acceptable:
+                raise Exception("TLS configuration must be a bool or an ssl.SSLContext")
+    return True

--- a/autobahn/twisted/test/test_transport.py
+++ b/autobahn/twisted/test/test_transport.py
@@ -1,0 +1,138 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+from mock import patch
+
+from autobahn.twisted.connection import _check_twisted_endpoint
+from autobahn.wamp.connection import check_endpoint
+
+from twisted.trial import unittest
+from twisted.internet.endpoints import clientFromString, serverFromString
+from twisted.internet import reactor
+
+try:
+    from twisted.internet.ssl import optionsForClientTLS, CertificateOptions
+    _OLD_TWISTED = False
+except ImportError:
+    _OLD_TWISTED = True
+
+
+class TestEndpointTwistedObjects(unittest.TestCase):
+    """
+    Confirms we can pass real Twisted objects into check_endpoint
+    """
+    def test_endpoint_string_client(self):
+        with patch('autobahn.twisted.connection.clientFromString') as cfs:
+            self.assertTrue(_check_twisted_endpoint("tcp:host=localhost:port=1234"))
+            self.assertTrue(cfs.mock_called)
+
+    def test_endpoint_string_client_invalid(self):
+        # bonus points if we mock clientFromString to raise
+        # instead of depending on badparser being a bad plugin name?
+        self.assertRaises(Exception, _check_twisted_endpoint, "badparser:foo=bar")
+
+    def test_istream_client(self):
+        ep = clientFromString(reactor, "tcp:host=127.0.0.1:port=1234")
+        self.assertTrue(_check_twisted_endpoint(ep))
+
+    def test_istream_server_but_connect(self):
+        ep = serverFromString(reactor, "tcp:port=1234")
+        self.assertRaises(Exception, _check_twisted_endpoint, ep)
+
+    def test_bogus_endpoint(self):
+        self.assertRaises(Exception, _check_twisted_endpoint, object())
+
+    def test_bogus_endpoint_from_api(self):
+        self.assertRaises(
+            Exception, check_endpoint, object(),
+            check_native_endpoint=_check_twisted_endpoint,
+        )
+
+    def test_bogus_endpoint_from_api_no_checker(self):
+        self.assertRaises(
+            Exception, check_endpoint, object(),
+            check_native_endpoint=None,
+        )
+
+    def test_missing_native_check_tls(self):
+        # if we provide TLS, we *need* a native checker
+        self.assertRaises(
+            Exception, check_endpoint, dict(host="wamp.ws", tls=True),
+            check_native_endpoint=None,
+        )
+
+    def test_non_tcp_endpoint_from_api(self):
+        # should skip TLS-checking of non-TCP endpoints
+        self.assertTrue(
+            check_endpoint(
+                {
+                    "type": "unix",
+                    "path": "/dev/null",
+                },
+                check_native_endpoint=_check_twisted_endpoint,
+            )
+        )
+
+    def test_tcp_no_tls(self):
+        # should skip TLS checking if we don't provide any TLS config
+        # at all
+        self.assertTrue(
+            check_endpoint(
+                {
+                    "type": "tcp",
+                    "host": "127.0.0.1",
+                },
+                check_native_endpoint=_check_twisted_endpoint,
+            )
+        )
+
+    def test_tls_wrong_bool(self):
+        self.assertRaises(
+            Exception, _check_twisted_endpoint,
+            {
+                "host": "wamp.ws",
+                "tls": False,
+            },
+        )
+
+    def test_tls_bool(self):
+        if _OLD_TWISTED:
+            raise unittest.SkipTest()
+        self.assertTrue(_check_twisted_endpoint({"tls": True}))
+
+    def test_tls_certificate_options(self):
+        if _OLD_TWISTED:
+            raise unittest.SkipTest()
+        co = CertificateOptions()
+        self.assertTrue(_check_twisted_endpoint({"tls": co}))
+
+    def test_tls_connection_creator(self):
+        if _OLD_TWISTED:
+            raise unittest.SkipTest()
+        co = optionsForClientTLS(u"example.com")
+        self.assertTrue(_check_twisted_endpoint({"tls": co}))

--- a/autobahn/wamp/connection.py
+++ b/autobahn/wamp/connection.py
@@ -41,43 +41,122 @@ __all__ = ('Connection')
 
 def check_endpoint(endpoint, check_native_endpoint=None):
     """
-    Check a WAMP connecting endpoint configuration.
-    """
-    if type(endpoint) != dict:
-        check_native_endpoint(endpoint)
-    else:
-        if 'type' not in endpoint:
-            raise RuntimeError('missing type in endpoint')
-        if endpoint['type'] not in ['tcp', 'unix']:
-            raise RuntimeError('invalid type "{}" in endpoint'.format(endpoint['type']))
+    :param listen: True if this transport will be used for listening
 
-        if endpoint['type'] == 'tcp':
-            pass
-        elif endpoint['type'] == 'unix':
-            pass
-        else:
-            assert(False), 'should not arrive here'
+    :param endpoint:
+
+        A dict defining a network endpoint, consisting of the following keys:
+
+        - type: "tcp" or "unix" (default: tcp)
+        - port: (mandatory for TCP) any valid port number
+        - version: "4" or "6" (default: 4)
+        - host: (non-listen only) the host to connect to (or IP address)
+        - interface: (optional; TCP listen only) explicit interface to listen on (default: any)
+        - backlog: (optional; listen only) accept-queue depth (default: 50)
+        - timeout: (optional; non-listen only) connection timeout in seconds (default: 10)
+        - shared: (optional; TCP listen only) share socket amongst other processes (default: False)
+        - tls: (optional; TCP only) dict of TLS options
+
+        If using Twisted, an "endpoint" can be any object providing
+        IStreamClientEndpoint *or* a string that ``clientFromString``
+        successfully parses.
+
+    :returns: True if this is a valid endpoint, or an exception otherwise
+    """
+
+    if type(endpoint) != dict:
+        # if the endpoint isn't a dict, it *must* be a valid "native"
+        # object
+        if check_native_endpoint is None:
+            raise Exception("'endpoint' configuration must be a dict")
+        return check_native_endpoint(endpoint)
+
+    # we *do* have a dict here, but we still want to call the native
+    # checker if it's available -- for example, if TLS is configured
+    # but we have an older Twisted, this fails.
+    if check_native_endpoint is not None:
+        check_native_endpoint(endpoint)
+
+    valid_keys = ['type', 'port', 'version', 'tls', 'path', 'host', 'timeout']
+    for key in endpoint.keys():
+        if key not in valid_keys:
+            raise Exception("Invalid endpoint key '{0}'".format(key))
+
+    kind = endpoint.get('type', 'tcp')
+    if kind not in ['tcp', 'unix']:
+        raise Exception("Unknown endpoint kind '{0}'".format(kind))
+
+    if kind == 'tcp':
+        if 'path' in endpoint:
+            raise Exception("'tcp' endpoints do not accept 'path'")
+        if 'host' not in endpoint:
+            raise Exception("Client endpoints require 'host'")
+        version = endpoint.get('version', 4)
+        if version not in [4, 6]:
+            raise Exception("Only TCP versions 4 or 6 accepted")
+
+        # 'tls' values are checked by the native checkers
+        if 'tls' in endpoint:
+            assert check_native_endpoint is not None
+    else:
+        for x in ['host', 'port', 'tls', 'shared', 'version']:
+            if x in endpoint:
+                raise Exception("'{0}' not accepted for unix endpoint".format(x))
+
+        if 'path' not in endpoint:
+            raise Exception("unix endpoints require 'path'")
+
+    timeout = float(endpoint.get('timeout', 10))
+    if timeout <= 0.0:
+        raise Exception("Invalid timeout '{0}'".format(timeout))
+
+    return True
 
 
 def check_transport(transport, check_native_endpoint=None):
     """
-    Check a WAMP connecting transport configuration.
+    :param transport:
+        a dict defining a WAMP transport. A WAMP transport definition
+        consists of the following fields:
+
+        - type: "websocket" or "rawsocket" (default: websocket)
+        - url: (only if type==websocket) the websocket url, like ws://demo.crossbar.io/ws
+        - endpoint: (optional) a dict defining a network endpoint (see :meth:`check_endpoint`)
+
+    :returns: True if this is a valid WAMP transport, or an exception otherwise
     """
-    if type(transport) != dict:
-        raise RuntimeError('invalid type {} for transport configuration - must be a dict'.format(type(transport)))
+    for key in transport.keys():
+        if key not in ['type', 'url', 'endpoint']:
+            raise Exception("Unknown key '{0}' in transport config".format(key))
 
-    if 'type' not in transport:
-        raise RuntimeError('missing type in transport')
+    kind = transport.get('type', 'websocket')
+    if kind not in ['websocket', 'rawsocket']:
+        raise Exception("Unknown transport type '{0}'".format(kind))
 
-    if transport['type'] not in ['websocket', 'rawsocket']:
-        raise RuntimeError('invalid transport type {}'.format(transport['type']))
+    if 'url' in transport:
+        assert(type(transport['url']) == six.text_type)
 
-    if transport['type'] == 'websocket':
-        pass
-    elif transport['type'] == 'rawsocket':
-        pass
+    if kind == 'websocket':
+        if 'url' not in transport:
+            raise Exception("'url' is required in transport")
+        is_secure, host, port, resource, path, params = parseWsUrl(transport['url'])
+        if 'endpoint' in transport:
+            if not is_secure and 'tls' in transport['endpoint'] and transport['endpoint']['tls']:
+                raise RuntimeError(
+                    '"tls" key conflicts with the "ws:" prefix of the url'
+                    ' argument. Did you mean to use "wss:"?'
+                )
+
+    if 'endpoint' in transport:
+        return check_endpoint(
+            transport['endpoint'],
+            check_native_endpoint=check_native_endpoint,
+        )
     else:
-        assert(False), 'should not arrive here'
+        if kind != 'websocket':
+            raise RuntimeError("Must provide 'endpoint' configuration "
+                               "for '{0}'".format(transport['type']))
+        return True
 
 
 class Transport(object):

--- a/autobahn/wamp/connection.py
+++ b/autobahn/wamp/connection.py
@@ -50,11 +50,8 @@ def check_endpoint(endpoint, check_native_endpoint=None):
         - type: "tcp" or "unix" (default: tcp)
         - port: (mandatory for TCP) any valid port number
         - version: "4" or "6" (default: 4)
-        - host: (non-listen only) the host to connect to (or IP address)
-        - interface: (optional; TCP listen only) explicit interface to listen on (default: any)
-        - backlog: (optional; listen only) accept-queue depth (default: 50)
-        - timeout: (optional; non-listen only) connection timeout in seconds (default: 10)
-        - shared: (optional; TCP listen only) share socket amongst other processes (default: False)
+        - host: the host to connect to (or IP address)
+        - timeout: (optional) connection timeout in seconds (default: 10)
         - tls: (optional; TCP only) dict of TLS options
 
         If using Twisted, an "endpoint" can be any object providing

--- a/autobahn/wamp/test/test_transport.py
+++ b/autobahn/wamp/test/test_transport.py
@@ -1,0 +1,198 @@
+###############################################################################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) Tavendo GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+###############################################################################
+
+from __future__ import absolute_import
+
+import unittest2 as unittest
+
+from autobahn.wamp.connection import check_transport, check_endpoint
+
+
+class TestTransportParsing(unittest.TestCase):
+
+    def test_invalid_key(self):
+        self.assertRaises(Exception, check_transport, {"foo": "bar"})
+
+    def test_invalid_type(self):
+        self.assertRaises(Exception, check_transport, {"type": "invalid"})
+
+    def test_rawsocket(self):
+        self.assertRaises(RuntimeError, check_transport,
+                          {
+                              "type": "rawsocket",
+                          })
+
+    def test_websocket_valid(self):
+        self.assertTrue(
+            check_transport(
+                {
+                    "type": "websocket",
+                    "url": u"ws://127.0.0.1/ws",
+                }
+            )
+        )
+
+    def test_websocket_no_url(self):
+        self.assertRaises(Exception, check_transport,
+                          {
+                              "type": "websocket",
+                          })
+
+    def test_websocket_secure_but_ws(self):
+        self.assertRaises(Exception, check_transport,
+                          {
+                              "type": "websocket",
+                              "url": u"ws://127.0.0.1/ws",
+                              "endpoint": {
+                                  "tls": True,
+                              }
+                          })
+
+    def test_valid(self):
+        self.assertTrue(
+            check_transport(
+                {
+                    "type": "websocket",
+                    "url": u"ws://127.0.0.1/ws",
+                    "endpoint": {
+                        "host": "127.0.0.1",
+                        "port": 1234,
+                    }
+                }
+            )
+        )
+
+    def test_(self):
+        self.assertRaises(Exception, check_transport, {"type": "websocket"})
+
+
+class TestEndpointParsing(unittest.TestCase):
+
+    def test_invalid_key(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "invalid": "key",
+            }
+        )
+
+    def test_invalid_kind(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "type": "something_strange",
+            }
+        )
+
+    def test_tcp_invalid_keys(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "type": "tcp",
+                "path": "foo",
+            }
+        )
+
+    def test_tcp_no_host(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "type": "tcp",
+            }
+        )
+
+    def test_tcp_invalid_version(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "version": 1,
+                "host": "127.0.0.1",
+            }
+        )
+
+    def test_unix_invalid_keys(self):
+        for bad_key in ['host', 'port', 'interface', 'tls', 'shared', 'version']:
+            self.assertRaises(
+                Exception, check_endpoint,
+                {
+                    "type": "unix",
+                    bad_key: "value",
+                }
+            )
+
+    def test_unix_no_path(self):
+        self.assertRaises(
+            Exception, check_endpoint,
+            {
+                "type": "unix",
+            }
+        )
+
+    def test_unix_valid(self):
+        self.assertTrue(
+            check_endpoint(
+                {
+                    "type": "unix",
+                    "path": "/tmp/foo",
+                }
+            )
+        )
+
+    def test_timeout(self):
+        self.assertTrue(
+            check_endpoint(
+                {
+                    "type": "tcp",
+                    "host": "127.0.0.1",
+                    "port": 1234,
+                    "timeout": 123.456,
+                }
+            )
+        )
+
+    def test_negative_timeout(self):
+        self.assertRaises(
+            Exception,
+            check_endpoint,
+            {
+                "type": "tcp",
+                "host": "127.0.0.1",
+                "port": 1234,
+                "timeout": -123.456,
+            }
+        )
+
+    def test_bad_connecting_keys(self):
+        for bad_key in ['backlog', 'shared', 'interface']:
+            self.assertRaises(
+                Exception,
+                check_endpoint,
+                {
+                    "type": "tcp",
+                    "host": "127.0.0.1",
+                    bad_key: "value",
+                }
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,11 @@ deps =
     unittest2
     coverage
     msgpack-python
+    pyOpenSSL
+    service-identity
     git+https://github.com/tavendo/txaio
+
+    py26: ordereddict
 
     ; twisted dependencies
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,13 @@ deps =
     unittest2
     coverage
     msgpack-python
-    pyOpenSSL
-    service-identity
     git+https://github.com/tavendo/txaio
 
     py26: ordereddict
+
+    py27,py34,py33: pyOpenSSL
+    py27,py34,py33: service-identity
+
 
     ; twisted dependencies
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip


### PR DESCRIPTION
Ported from refactor-transports branch; includes unit-tests and
split out "native" (asyncio/twisted) checking code.