### PR TITLE
Rely on __str__() to extract exception information

### DIFF
--- a/autobahn/wamp/protocol.py
+++ b/autobahn/wamp/protocol.py
@@ -604,7 +604,7 @@ class ApplicationSession(BaseSession):
 
                         def error(err):
                             # errmsg = 'Failure while invoking procedure {0} registered under "{1}: {2}".'.format(endpoint.fn, registration.procedure, err)
-                            errmsg = u"{0}".format(err.value.args[0])
+                            errmsg = u"{0}".format(err.value)
                             try:
                                 self.onUserError(err, errmsg)
                             except:


### PR DESCRIPTION
For the purpose of extracting exception messages from possible user-defined exceptions (which is the case of #484), the best approach IMHO is relying on `__str__()`.

This patch does this when handling exceptions from INVOCATION endpoints.

Fix #484.