### PR TITLE
Replace NoneType with type(None)

### DIFF
--- a/autobahn/twisted/util.py
+++ b/autobahn/twisted/util.py
@@ -32,7 +32,7 @@ try:
     from twisted.internet.stdio import PipeAddress
 except ImportError:
     # stdio.PipeAddress isn't avail on Twisted 13.0+
-    from types import NoneType as PipeAddress
+    PipeAddress = type(None)
 
 try:
     from twisted.internet.address import IPv6Address


### PR DESCRIPTION
Fixes Py3+Twisted 15 compatibility and all fails from https://travis-ci.org/tavendo/AutobahnPython/builds/82086496.